### PR TITLE
feat(gov): vote-from-the-vault backend (lookup, voteraw relay, rate-limit)

### DIFF
--- a/lib/appFactory.js
+++ b/lib/appFactory.js
@@ -15,6 +15,7 @@ const { createCsrfMiddleware } = require('../middleware/csrf');
 const rateLimiters = require('../middleware/rateLimit');
 const { createAuthRouter } = require('../routes/auth');
 const { createVaultRouter } = require('../routes/vault');
+const { createGovRouter } = require('../routes/gov');
 
 // Build the stateful services (repos + middlewares) around a DB handle.
 // Pure-ish: no Express side effects yet, so the same object graph can be
@@ -71,6 +72,8 @@ function mountAuthAndVault(
     disableRateLimit = process.env.NODE_ENV === 'test',
     scheduler,
     now = () => Date.now(),
+    masternodesProvider,
+    voteRaw,
   }
 ) {
   if (!services.sessionMw) finalizeSessionMw(services);
@@ -78,10 +81,12 @@ function mountAuthAndVault(
     ? {
         login: rateLimiters.disabled(),
         register: rateLimiters.disabled(),
+        vote: rateLimiters.disabled(),
       }
     : {
         login: rateLimiters.loginLimiter(),
         register: rateLimiters.registerLimiter(),
+        vote: rateLimiters.voteLimiter(),
       };
 
   app.use(
@@ -110,6 +115,24 @@ function mountAuthAndVault(
     })
   );
 
+  // /gov is optional: only mount it when the caller has wired the
+  // Syscoin RPC + masternode tracker. The legacy `server.js` path
+  // always provides both; tests wire fakes or omit them entirely if
+  // they only exercise /auth / /vault.
+  if (typeof masternodesProvider === 'function' && typeof voteRaw === 'function') {
+    app.use(
+      '/gov',
+      createGovRouter({
+        masternodesProvider,
+        voteRaw,
+        sessionMw: services.sessionMw,
+        csrfMw: services.csrfMw,
+        voteLimiter: limiters.vote,
+        nowMs: now,
+      })
+    );
+  }
+
   // Last-chance error-handling middleware for /auth and /vault.
   //
   // Express 4 does not automatically route rejected async-handler
@@ -121,7 +144,7 @@ function mountAuthAndVault(
   // (e.g. body-parser PayloadTooLargeError → 413) and only default to
   // 500 for uncategorized throws. (Codex round-9 P1 defense.)
   // eslint-disable-next-line no-unused-vars
-  app.use(['/auth', '/vault'], (err, req, res, _next) => {
+  app.use(['/auth', '/vault', '/gov'], (err, req, res, _next) => {
     if (res.headersSent) return;
     // Body-parser + a few other middlewares attach a `.status`/`.statusCode`
     // to errors that represent well-formed HTTP responses. Honor those so
@@ -157,6 +180,8 @@ function createApp({
     'http://localhost:3000',
   disableRateLimit = process.env.NODE_ENV === 'test',
   scheduler,
+  masternodesProvider,
+  voteRaw,
 } = {}) {
   if (!db) throw new Error('appFactory: db is required');
   if (!mailer) throw new Error('appFactory: mailer is required');
@@ -178,6 +203,8 @@ function createApp({
     disableRateLimit,
     scheduler,
     now,
+    masternodesProvider,
+    voteRaw,
   });
 
   app.get('/health', (_req, res) => res.json({ ok: true }));

--- a/lib/credentialedPaths.js
+++ b/lib/credentialedPaths.js
@@ -1,0 +1,36 @@
+// Credentialed-CORS path selector used by server.js.
+//
+// Separated into its own module (and its own test file) so the
+// boundary semantics — "exactly /prefix OR starts with /prefix/" —
+// can be verified in isolation from Express/middleware wiring.
+//
+// Why the boundary matters:
+//
+// Legacy public routes (`routes/governance.js` et al.) register
+// paths like `/govlist`, `/govbyhash` that are served to third-party
+// consumers under `origin: '*'`. The new authenticated governance
+// surface registers `/gov/...` and MUST be served under the
+// credentialed `origin: <SPA>, credentials: true` CORS profile or
+// browsers reject the preflight.
+//
+// A naive `path.startsWith('/gov')` catches BOTH buckets: it would
+// route legacy `/govlist` through the credentialed profile, which
+// sends `Access-Control-Allow-Origin: <SPA>` and therefore 403s
+// every other origin. That's a regression against every third-party
+// integration that's ever polled the public governance list.
+//
+// The path-boundary match below is the only correct prefix test
+// when you have sibling routes that differ only in the trailing
+// characters of the prefix itself. (Express's own `app.use('/gov',
+// ...)` applies the same boundary rule under the hood.)
+
+const CREDENTIALED_PREFIXES = Object.freeze(['/auth', '/vault', '/gov']);
+
+function isCredentialedPath(path) {
+  if (typeof path !== 'string' || path.length === 0) return false;
+  return CREDENTIALED_PREFIXES.some(
+    (p) => path === p || path.startsWith(p + '/')
+  );
+}
+
+module.exports = { CREDENTIALED_PREFIXES, isCredentialedPath };

--- a/lib/credentialedPaths.test.js
+++ b/lib/credentialedPaths.test.js
@@ -1,0 +1,42 @@
+const { isCredentialedPath } = require('./credentialedPaths');
+
+describe('isCredentialedPath', () => {
+  test.each([
+    ['/auth', true],
+    ['/auth/login', true],
+    ['/auth/register', true],
+    ['/vault', true],
+    ['/vault/get', true],
+    ['/gov', true],
+    ['/gov/mns/lookup', true],
+    ['/gov/vote', true],
+  ])('%s is credentialed', (path, expected) => {
+    expect(isCredentialedPath(path)).toBe(expected);
+  });
+
+  // These are the legacy public endpoints that used to sit under
+  // `origin: '*'`. A naive startsWith('/gov') match would wrongly
+  // pull them into the credentialed bucket and break every third-
+  // party consumer that isn't hosted on CORS_ORIGIN. These
+  // assertions are the regression test for Codex P1 on server.js.
+  test.each([
+    ['/govlist', false],
+    ['/govbyhash', false],
+    ['/authenticate', false], // hypothetical future legacy path
+    ['/vaultpublic', false], // hypothetical future legacy path
+    ['/mnstats', false],
+    ['/', false],
+    ['/health', false],
+  ])('%s is NOT credentialed (boundary check)', (path, expected) => {
+    expect(isCredentialedPath(path)).toBe(expected);
+  });
+
+  test.each([
+    [null, false],
+    [undefined, false],
+    ['', false],
+    [42, false],
+  ])('rejects %p (non-string / empty)', (input, expected) => {
+    expect(isCredentialedPath(input)).toBe(expected);
+  });
+});

--- a/lib/gov.js
+++ b/lib/gov.js
@@ -23,10 +23,18 @@
 // (UI copy / i18n keys hang off them).
 
 const HEX64 = /^[0-9a-fA-F]{64}$/;
-// Permissive base64: alphabet + optional "=" padding. We size-check
-// separately (65 raw bytes → 88 base64 chars with padding) so a
-// wrong-length signature is surfaced with its own dedicated code.
+// Permissive base64 charset guard: the real length/shape check happens
+// via `Buffer.from(sig, 'base64').length === 65` plus a canonical
+// re-encode roundtrip, so the regex is just a cheap filter that
+// rejects obviously malformed input (whitespace, non-base64 chars)
+// before we allocate a decode buffer.
 const BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+// A recoverable ECDSA signature produced by CKey::SignCompact is
+// exactly 65 bytes (1-byte header + 32-byte r + 32-byte s). Anything
+// else is a programming or tampering error — Core would reject it at
+// `voteraw` anyway, but we fail fast here with a stable error code
+// so the UI can surface a precise message.
+const VOTE_SIG_BYTES = 65;
 
 const OUTCOMES = Object.freeze({ yes: 1, no: 2, abstain: 3 });
 // PR5 intentionally supports only `funding`. The other signals
@@ -137,12 +145,24 @@ function validateVoteBody(body, { nowMs = Date.now() } = {}) {
     ) {
       return { ok: false, error: `invalid_entry:${i}:collateralIndex` };
     }
-    if (typeof voteSig !== "string" || voteSig.length < 88 || voteSig.length > 92) {
-      // 65 raw bytes base64 = 88 chars padded; accept up to 92 chars
-      // to tolerate whitespace-stripped or alternate-padded strings.
+    if (typeof voteSig !== "string" || !BASE64.test(voteSig)) {
       return { ok: false, error: `invalid_entry:${i}:voteSig` };
     }
-    if (!BASE64.test(voteSig)) {
+    // Decode and verify the exact raw length. The character-count
+    // check we used to perform accepted `"A".repeat(88)` (decodes to
+    // 66 bytes) and `"A".repeat(86) + "=="` (decodes to 64 bytes)
+    // because both are syntactically valid base64 strings of the
+    // "right" length. Decoding is the only way to enforce the 65-
+    // byte invariant. We also require the roundtrip
+    // (decode → re-encode) to equal the input so non-canonical
+    // padding (extra "=" chars, non-zero trailing bits) is rejected.
+    // `Buffer.from(_, 'base64')` never throws on junk input — it
+    // silently coerces — so both checks are load-bearing here.
+    const decodedSig = Buffer.from(voteSig, "base64");
+    if (
+      decodedSig.length !== VOTE_SIG_BYTES ||
+      decodedSig.toString("base64") !== voteSig
+    ) {
       return { ok: false, error: `invalid_entry:${i}:voteSig` };
     }
     const k = `${collateralHash.toLowerCase()}:${collateralIndex}`;

--- a/lib/gov.js
+++ b/lib/gov.js
@@ -1,0 +1,328 @@
+// Governance voting — pure domain logic.
+//
+// Lives in lib/ (not routes/) so every branch can be unit-tested
+// without Express, and so the RPC client + MN store can be injected
+// at the HTTP seam in routes/gov.js. Nothing here reaches for the
+// network.
+//
+// Scope (PR 5):
+//   * MN lookup by votingaddress against the tracker's in-memory
+//     cache. Used by the frontend to identify which of the user's
+//     imported voting keys correspond to live masternodes.
+//   * Vote-relay validation + fan-out. The browser signs locally
+//     (VaultGovernanceSigner / voteSigner.js), and we relay each
+//     compact ECDSA signature to Syscoin Core's `voteraw` RPC. We
+//     intentionally enforce `voteSignal === "funding"` here — non-
+//     funding signals (valid/delete/endorsed) use the BLS operator
+//     key, NOT the voting key, and the vault doesn't hold operator
+//     keys.
+//
+// Error taxonomy for validation: we return `{ ok: false, error: "<code>" }`
+// rather than throwing, so the HTTP layer maps codes to 4xx without
+// rebuilding error objects across module boundaries. Codes are stable
+// (UI copy / i18n keys hang off them).
+
+const HEX64 = /^[0-9a-fA-F]{64}$/;
+// Permissive base64: alphabet + optional "=" padding. We size-check
+// separately (65 raw bytes → 88 base64 chars with padding) so a
+// wrong-length signature is surfaced with its own dedicated code.
+const BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+
+const OUTCOMES = Object.freeze({ yes: 1, no: 2, abstain: 3 });
+// PR5 intentionally supports only `funding`. The other signals
+// (valid/delete/endorsed) require the masternode operator's BLS
+// key — a separate custody story. We reject them here rather than
+// silently accepting + failing at Core, so the UI can render an
+// explicit "not supported" hint.
+const SIGNALS = Object.freeze({ funding: 1 });
+
+// Absolute caps, deliberate and defensible:
+//   - lookup: 512 addresses per call (a heavy MN operator might
+//     have ~100 keys; 512 leaves 5x headroom).
+//   - vote:   256 entries per call (same ceiling with headroom).
+// Both walk O(n) arrays; 512 × 2000 MNs is still <1M comparisons.
+const MAX_LOOKUP_ADDRESSES = 512;
+const MAX_VOTE_ENTRIES = 256;
+
+// Core's `CGovernanceVote::IsValid` rejects votes with `nTime > now + 3600`.
+// Anything older is accepted by Core (propagation / replay), so the
+// lower bound we enforce is a soft antifraud window (2h back) — if a
+// user's wall clock is >2h behind, they'll get a clear error here rather
+// than a confusing downstream rejection.
+const VOTE_TIME_MAX_SKEW_AHEAD_S = 60 * 60;          // +1 h (Core-enforced)
+const VOTE_TIME_MAX_SKEW_BEHIND_S = 2 * 60 * 60;     // -2 h (client-hygiene)
+
+// ---------------------------------------------------------------------
+// Pure validators
+// ---------------------------------------------------------------------
+
+function validateLookupBody(body) {
+  if (!body || typeof body !== "object") {
+    return { ok: false, error: "invalid_body" };
+  }
+  const { votingAddresses } = body;
+  if (!Array.isArray(votingAddresses)) {
+    return { ok: false, error: "invalid_body" };
+  }
+  if (votingAddresses.length === 0) {
+    return { ok: true, votingAddresses: [] };
+  }
+  if (votingAddresses.length > MAX_LOOKUP_ADDRESSES) {
+    return { ok: false, error: "too_many_addresses" };
+  }
+  const cleaned = [];
+  for (const a of votingAddresses) {
+    if (typeof a !== "string" || a.length === 0 || a.length > 128) {
+      return { ok: false, error: "invalid_address" };
+    }
+    // We don't validate the bech32 HRP here — Syscoin mainnet voting
+    // addresses always start with `sys1q` in practice, but we want
+    // the lookup to silently return no match for malformed inputs
+    // rather than 400. That matches the frontend UX: a typo'd
+    // address shows "no matching masternode" rather than a hard
+    // error.
+    cleaned.push(a.trim());
+  }
+  return { ok: true, votingAddresses: cleaned };
+}
+
+function validateVoteBody(body, { nowMs = Date.now() } = {}) {
+  if (!body || typeof body !== "object") {
+    return { ok: false, error: "invalid_body" };
+  }
+  const { proposalHash, voteOutcome, voteSignal, time, entries } = body;
+
+  if (typeof proposalHash !== "string" || !HEX64.test(proposalHash)) {
+    return { ok: false, error: "invalid_proposal_hash" };
+  }
+  if (typeof voteOutcome !== "string" || !(voteOutcome in OUTCOMES)) {
+    return { ok: false, error: "invalid_vote_outcome" };
+  }
+  if (typeof voteSignal !== "string" || !(voteSignal in SIGNALS)) {
+    // PR5 limits this to "funding" — see comment on SIGNALS above.
+    return { ok: false, error: "unsupported_vote_signal" };
+  }
+  if (!Number.isInteger(time) || time < 0) {
+    return { ok: false, error: "invalid_time" };
+  }
+  const nowS = Math.floor(nowMs / 1000);
+  if (time > nowS + VOTE_TIME_MAX_SKEW_AHEAD_S) {
+    return { ok: false, error: "time_in_future" };
+  }
+  if (time < nowS - VOTE_TIME_MAX_SKEW_BEHIND_S) {
+    return { ok: false, error: "time_too_old" };
+  }
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return { ok: false, error: "no_entries" };
+  }
+  if (entries.length > MAX_VOTE_ENTRIES) {
+    return { ok: false, error: "too_many_entries" };
+  }
+
+  const cleaned = [];
+  const dupKey = new Set();
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (!e || typeof e !== "object") {
+      return { ok: false, error: `invalid_entry:${i}` };
+    }
+    const { collateralHash, collateralIndex, voteSig } = e;
+    if (typeof collateralHash !== "string" || !HEX64.test(collateralHash)) {
+      return { ok: false, error: `invalid_entry:${i}:collateralHash` };
+    }
+    if (
+      !Number.isInteger(collateralIndex) ||
+      collateralIndex < 0 ||
+      collateralIndex > 0xffffffff
+    ) {
+      return { ok: false, error: `invalid_entry:${i}:collateralIndex` };
+    }
+    if (typeof voteSig !== "string" || voteSig.length < 88 || voteSig.length > 92) {
+      // 65 raw bytes base64 = 88 chars padded; accept up to 92 chars
+      // to tolerate whitespace-stripped or alternate-padded strings.
+      return { ok: false, error: `invalid_entry:${i}:voteSig` };
+    }
+    if (!BASE64.test(voteSig)) {
+      return { ok: false, error: `invalid_entry:${i}:voteSig` };
+    }
+    const k = `${collateralHash.toLowerCase()}:${collateralIndex}`;
+    if (dupKey.has(k)) {
+      return { ok: false, error: `duplicate_entry:${i}` };
+    }
+    dupKey.add(k);
+    cleaned.push({
+      collateralHash: collateralHash.toLowerCase(),
+      collateralIndex,
+      voteSig,
+    });
+  }
+
+  return {
+    ok: true,
+    proposalHash: proposalHash.toLowerCase(),
+    voteOutcome,
+    voteSignal,
+    time,
+    entries: cleaned,
+  };
+}
+
+// ---------------------------------------------------------------------
+// MN lookup
+// ---------------------------------------------------------------------
+
+// Project the tracker's MN object into the subset the frontend
+// actually needs. Keeps the wire format stable even if the tracker
+// grows more fields later.
+function projectMatch(mn) {
+  return {
+    votingaddress: typeof mn.votingaddress === "string" ? mn.votingaddress : "",
+    proTxHash: typeof mn.proTxHash === "string" ? mn.proTxHash : "",
+    collateralHash:
+      typeof mn.collateralHash === "string" ? mn.collateralHash : null,
+    collateralIndex: Number.isInteger(mn.collateralIndex)
+      ? mn.collateralIndex
+      : null,
+    status: typeof mn.status === "string" ? mn.status : "UNKNOWN",
+    address: typeof mn.address === "string" ? mn.address : "",
+    payee: typeof mn.payee === "string" ? mn.payee : "",
+  };
+}
+
+function lookupMatches(masternodesArr, votingAddresses) {
+  if (!Array.isArray(masternodesArr) || masternodesArr.length === 0) {
+    return [];
+  }
+  if (!Array.isArray(votingAddresses) || votingAddresses.length === 0) {
+    return [];
+  }
+  // Case-insensitive match. bech32 is lowercase by spec but we
+  // normalise both sides so an uppercase paste still works.
+  const want = new Set(
+    votingAddresses.map((a) => String(a).toLowerCase())
+  );
+  const matches = [];
+  // Single pass over the MN array. O(n) where n ≈ 2-3k MNs on
+  // mainnet — trivial at any call rate the rate-limiter allows.
+  for (const mn of masternodesArr) {
+    if (!mn || typeof mn.votingaddress !== "string") continue;
+    if (!want.has(mn.votingaddress.toLowerCase())) continue;
+    // Only surface MNs with a usable collateral outpoint — a MN
+    // without a parsed outpoint cannot participate in /gov/vote, so
+    // including it would just mislead the UI into offering an action
+    // that will fail downstream.
+    if (
+      typeof mn.collateralHash !== "string" ||
+      !HEX64.test(mn.collateralHash) ||
+      !Number.isInteger(mn.collateralIndex)
+    ) {
+      continue;
+    }
+    matches.push(projectMatch(mn));
+  }
+  return matches;
+}
+
+// ---------------------------------------------------------------------
+// Vote relay
+// ---------------------------------------------------------------------
+
+// Run `work` with at most `concurrency` active promises at a time.
+// Resolves to an array preserving input order. Rejections become
+// resolved {ok:false,error} objects via the `wrap` contract so a
+// single failing MN never sinks the batch.
+async function mapLimited(items, concurrency, work) {
+  const out = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      out[i] = await work(items[i], i);
+    }
+  }
+  const n = Math.max(1, Math.min(concurrency, items.length));
+  const workers = Array.from({ length: n }, () => worker());
+  await Promise.all(workers);
+  return out;
+}
+
+// Map RPC error messages into stable, UI-safe codes. Anything we
+// don't recognise is passed through as a generic "rpc_error" so the
+// frontend can show a fallback message without leaking internals
+// (the full message is still available in logs server-side).
+function classifyRpcError(msg) {
+  if (typeof msg !== "string") return "rpc_error";
+  const s = msg.toLowerCase();
+  if (s.includes("failure to find masternode")) return "mn_not_found";
+  if (s.includes("failure to verify vote")) return "signature_invalid";
+  if (s.includes("masternode voting too often")) return "vote_too_often";
+  if (s.includes("governance object not found")) return "proposal_not_found";
+  if (s.includes("invalid vote signal")) return "invalid_vote_signal";
+  if (s.includes("invalid vote outcome")) return "invalid_vote_outcome";
+  if (s.includes("malformed base64")) return "signature_malformed";
+  if (s.includes("already known valid vote")) return "already_voted";
+  return "rpc_error";
+}
+
+// Relay a batch of pre-signed votes to Core via `voteraw`. `voteRaw` is
+// injected — the production wiring is
+//   rpcServices(client.callRpc).voteRaw(...).call(true)
+// (see services/rpcClient.js). Tests pass a fake that resolves /
+// rejects deterministically.
+async function relayVotes(
+  voteRaw,
+  { proposalHash, voteOutcome, voteSignal, time, entries },
+  { concurrency = 4 } = {}
+) {
+  if (typeof voteRaw !== "function") {
+    throw new Error("relayVotes: voteRaw function is required");
+  }
+  const results = await mapLimited(entries, concurrency, async (e) => {
+    try {
+      // Core returns "Voted successfully" on success; we don't care
+      // about the body, only the absence of a throw.
+      await voteRaw(
+        e.collateralHash,
+        e.collateralIndex,
+        proposalHash,
+        voteSignal,
+        voteOutcome,
+        time,
+        e.voteSig
+      );
+      return {
+        collateralHash: e.collateralHash,
+        collateralIndex: e.collateralIndex,
+        ok: true,
+      };
+    } catch (err) {
+      const message = (err && err.message) || String(err);
+      return {
+        collateralHash: e.collateralHash,
+        collateralIndex: e.collateralIndex,
+        ok: false,
+        error: classifyRpcError(message),
+      };
+    }
+  });
+  return {
+    accepted: results.filter((r) => r.ok).length,
+    rejected: results.filter((r) => !r.ok).length,
+    results,
+  };
+}
+
+module.exports = {
+  OUTCOMES,
+  SIGNALS,
+  MAX_LOOKUP_ADDRESSES,
+  MAX_VOTE_ENTRIES,
+  VOTE_TIME_MAX_SKEW_AHEAD_S,
+  VOTE_TIME_MAX_SKEW_BEHIND_S,
+  validateLookupBody,
+  validateVoteBody,
+  lookupMatches,
+  relayVotes,
+  classifyRpcError,
+};

--- a/lib/gov.test.js
+++ b/lib/gov.test.js
@@ -20,10 +20,11 @@ const VALID_HASH =
   '1111111111111111111111111111111111111111111111111111111111111111';
 const VALID_HASH_2 =
   '2222222222222222222222222222222222222222222222222222222222222222';
-// 65-byte compact sig base64. "AA...A" is syntactically valid base64
-// of the right length and avoids any risk of accidentally matching a
-// real signature.
-const SIG = 'A'.repeat(86) + '==';
+// 65-byte compact sig base64. 65 bytes of 0x00 encode to 87 "A"
+// characters followed by a single "=" padding char (canonical form).
+// We generate it from Buffer rather than hand-rolling the string so
+// the fixture stays in sync with Node's base64 encoder.
+const SIG = Buffer.alloc(65).toString('base64');
 
 describe('OUTCOMES / SIGNALS enum values match Syscoin Core', () => {
   test('outcomes use Core integer mapping', () => {
@@ -218,6 +219,24 @@ describe('validateVoteBody', () => {
     ['short', 'A'],
     ['non-base64', '!'.repeat(88)],
     ['oversized', 'A'.repeat(100)],
+    // 88 chars, no padding — decodes to 66 bytes, one too many.
+    // Charset-only validators accept this; the byte-length check
+    // is what rejects it.
+    ['decodes to 66 bytes', 'A'.repeat(88)],
+    // 86 chars + "==" — decodes to only 64 bytes. Syntactically a
+    // valid base64 string of the "right" length but the wrong
+    // payload size.
+    ['decodes to 64 bytes', 'A'.repeat(86) + '=='],
+    // Non-canonical encoding: swap the final data char in a valid
+    // 65-byte sig for "B", which has pad bits 0b01 instead of 0b00.
+    // The decoder silently discards those bits, yielding 65 zero
+    // bytes — re-encoding then produces a different string, so the
+    // roundtrip check fires. Belt-and-braces against encoders that
+    // might leak non-zero trailing bits.
+    [
+      'non-canonical trailing bits',
+      Buffer.alloc(65).toString('base64').slice(0, -2) + 'B=',
+    ],
   ])('rejects %s voteSig', (_label, voteSig) => {
     const bad = validateVoteBody(
       goodBody({

--- a/lib/gov.test.js
+++ b/lib/gov.test.js
@@ -1,0 +1,423 @@
+const {
+  OUTCOMES,
+  SIGNALS,
+  MAX_LOOKUP_ADDRESSES,
+  MAX_VOTE_ENTRIES,
+  validateLookupBody,
+  validateVoteBody,
+  lookupMatches,
+  relayVotes,
+  classifyRpcError,
+} = require('./gov');
+
+// Fixed test clock aligned to a "nTime" the validators accept. All time-
+// sensitive tests pass `nowMs` explicitly so the suite is deterministic
+// and doesn't drift on slow CI runners.
+const NOW_S = 1_700_000_000;
+const NOW_MS = NOW_S * 1000;
+
+const VALID_HASH =
+  '1111111111111111111111111111111111111111111111111111111111111111';
+const VALID_HASH_2 =
+  '2222222222222222222222222222222222222222222222222222222222222222';
+// 65-byte compact sig base64. "AA...A" is syntactically valid base64
+// of the right length and avoids any risk of accidentally matching a
+// real signature.
+const SIG = 'A'.repeat(86) + '==';
+
+describe('OUTCOMES / SIGNALS enum values match Syscoin Core', () => {
+  test('outcomes use Core integer mapping', () => {
+    expect(OUTCOMES).toEqual({ yes: 1, no: 2, abstain: 3 });
+  });
+  test('signals limited to funding in PR 5', () => {
+    expect(SIGNALS).toEqual({ funding: 1 });
+  });
+});
+
+describe('validateLookupBody', () => {
+  test('rejects non-object body', () => {
+    expect(validateLookupBody(null)).toEqual({ ok: false, error: 'invalid_body' });
+    expect(validateLookupBody('x')).toEqual({ ok: false, error: 'invalid_body' });
+  });
+  test('rejects non-array votingAddresses', () => {
+    expect(validateLookupBody({ votingAddresses: 'sys1q...' })).toEqual({
+      ok: false,
+      error: 'invalid_body',
+    });
+  });
+  test('accepts empty array as a trivial no-op', () => {
+    expect(validateLookupBody({ votingAddresses: [] })).toEqual({
+      ok: true,
+      votingAddresses: [],
+    });
+  });
+  test('enforces cap', () => {
+    const tooMany = Array.from(
+      { length: MAX_LOOKUP_ADDRESSES + 1 },
+      (_, i) => `sys1q${i}`
+    );
+    expect(validateLookupBody({ votingAddresses: tooMany })).toEqual({
+      ok: false,
+      error: 'too_many_addresses',
+    });
+  });
+  test('rejects non-string / empty / oversized entries', () => {
+    expect(
+      validateLookupBody({ votingAddresses: [''] })
+    ).toEqual({ ok: false, error: 'invalid_address' });
+    expect(
+      validateLookupBody({ votingAddresses: [123] })
+    ).toEqual({ ok: false, error: 'invalid_address' });
+    expect(
+      validateLookupBody({ votingAddresses: ['x'.repeat(200)] })
+    ).toEqual({ ok: false, error: 'invalid_address' });
+  });
+  test('trims whitespace on accepted entries', () => {
+    expect(
+      validateLookupBody({ votingAddresses: ['  sys1qabcdef  '] })
+    ).toEqual({ ok: true, votingAddresses: ['sys1qabcdef'] });
+  });
+});
+
+describe('validateVoteBody', () => {
+  function goodBody(overrides = {}) {
+    return {
+      proposalHash: VALID_HASH,
+      voteOutcome: 'yes',
+      voteSignal: 'funding',
+      time: NOW_S,
+      entries: [
+        { collateralHash: VALID_HASH_2, collateralIndex: 0, voteSig: SIG },
+      ],
+      ...overrides,
+    };
+  }
+
+  test('accepts a well-formed body', () => {
+    const out = validateVoteBody(goodBody(), { nowMs: NOW_MS });
+    expect(out.ok).toBe(true);
+    expect(out.proposalHash).toBe(VALID_HASH);
+    expect(out.voteOutcome).toBe('yes');
+    expect(out.voteSignal).toBe('funding');
+    expect(out.time).toBe(NOW_S);
+    expect(out.entries).toHaveLength(1);
+  });
+
+  test('rejects non-hex proposalHash', () => {
+    const bad = validateVoteBody(goodBody({ proposalHash: 'not-hex' }), {
+      nowMs: NOW_MS,
+    });
+    expect(bad).toEqual({ ok: false, error: 'invalid_proposal_hash' });
+  });
+
+  test('rejects non-64-char proposalHash', () => {
+    const bad = validateVoteBody(goodBody({ proposalHash: '1234' }), {
+      nowMs: NOW_MS,
+    });
+    expect(bad).toEqual({ ok: false, error: 'invalid_proposal_hash' });
+  });
+
+  test('rejects unknown outcome', () => {
+    const bad = validateVoteBody(goodBody({ voteOutcome: 'maybe' }), {
+      nowMs: NOW_MS,
+    });
+    expect(bad).toEqual({ ok: false, error: 'invalid_vote_outcome' });
+  });
+
+  test.each(['valid', 'delete', 'endorsed', 'none', ''])(
+    'rejects non-funding signal (%s) until PR 6',
+    (signal) => {
+      const bad = validateVoteBody(goodBody({ voteSignal: signal }), {
+        nowMs: NOW_MS,
+      });
+      expect(bad).toEqual({ ok: false, error: 'unsupported_vote_signal' });
+    }
+  );
+
+  test('rejects times more than 1h in the future (Core rule)', () => {
+    const bad = validateVoteBody(
+      goodBody({ time: NOW_S + 3601 }),
+      { nowMs: NOW_MS }
+    );
+    expect(bad).toEqual({ ok: false, error: 'time_in_future' });
+  });
+
+  test('accepts time exactly at the +1h boundary', () => {
+    const out = validateVoteBody(
+      goodBody({ time: NOW_S + 3600 }),
+      { nowMs: NOW_MS }
+    );
+    expect(out.ok).toBe(true);
+  });
+
+  test('rejects times more than 2h in the past', () => {
+    const bad = validateVoteBody(
+      goodBody({ time: NOW_S - 7201 }),
+      { nowMs: NOW_MS }
+    );
+    expect(bad).toEqual({ ok: false, error: 'time_too_old' });
+  });
+
+  test('rejects zero-length entries', () => {
+    const bad = validateVoteBody(goodBody({ entries: [] }), {
+      nowMs: NOW_MS,
+    });
+    expect(bad).toEqual({ ok: false, error: 'no_entries' });
+  });
+
+  test('enforces entry cap', () => {
+    const tooMany = Array.from({ length: MAX_VOTE_ENTRIES + 1 }, (_, i) => ({
+      collateralHash: VALID_HASH_2,
+      collateralIndex: i,
+      voteSig: SIG,
+    }));
+    const bad = validateVoteBody(goodBody({ entries: tooMany }), {
+      nowMs: NOW_MS,
+    });
+    expect(bad).toEqual({ ok: false, error: 'too_many_entries' });
+  });
+
+  test('rejects duplicate outpoints in one batch', () => {
+    const entries = [
+      { collateralHash: VALID_HASH_2, collateralIndex: 0, voteSig: SIG },
+      { collateralHash: VALID_HASH_2, collateralIndex: 0, voteSig: SIG },
+    ];
+    const bad = validateVoteBody(goodBody({ entries }), { nowMs: NOW_MS });
+    expect(bad).toEqual({ ok: false, error: 'duplicate_entry:1' });
+  });
+
+  test('same hash but different index is NOT a duplicate', () => {
+    const entries = [
+      { collateralHash: VALID_HASH_2, collateralIndex: 0, voteSig: SIG },
+      { collateralHash: VALID_HASH_2, collateralIndex: 1, voteSig: SIG },
+    ];
+    const out = validateVoteBody(goodBody({ entries }), { nowMs: NOW_MS });
+    expect(out.ok).toBe(true);
+  });
+
+  test('normalises proposal / collateral hash to lowercase', () => {
+    const out = validateVoteBody(
+      goodBody({
+        proposalHash: VALID_HASH.toUpperCase(),
+        entries: [
+          {
+            collateralHash: VALID_HASH_2.toUpperCase(),
+            collateralIndex: 3,
+            voteSig: SIG,
+          },
+        ],
+      }),
+      { nowMs: NOW_MS }
+    );
+    expect(out.ok).toBe(true);
+    expect(out.proposalHash).toBe(VALID_HASH);
+    expect(out.entries[0].collateralHash).toBe(VALID_HASH_2);
+  });
+
+  test.each([
+    ['short', 'A'],
+    ['non-base64', '!'.repeat(88)],
+    ['oversized', 'A'.repeat(100)],
+  ])('rejects %s voteSig', (_label, voteSig) => {
+    const bad = validateVoteBody(
+      goodBody({
+        entries: [
+          { collateralHash: VALID_HASH_2, collateralIndex: 0, voteSig },
+        ],
+      }),
+      { nowMs: NOW_MS }
+    );
+    expect(bad.ok).toBe(false);
+    expect(bad.error).toMatch(/voteSig$/);
+  });
+
+  test('rejects negative / fractional collateralIndex', () => {
+    for (const bad of [-1, 1.5, NaN, '0']) {
+      const res = validateVoteBody(
+        goodBody({
+          entries: [
+            {
+              collateralHash: VALID_HASH_2,
+              collateralIndex: bad,
+              voteSig: SIG,
+            },
+          ],
+        }),
+        { nowMs: NOW_MS }
+      );
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/collateralIndex$/);
+    }
+  });
+});
+
+describe('lookupMatches', () => {
+  function mn(overrides = {}) {
+    return {
+      votingaddress: 'sys1qaaa',
+      proTxHash: 'p1',
+      collateralHash: VALID_HASH,
+      collateralIndex: 0,
+      status: 'ENABLED',
+      address: '1.2.3.4:8369',
+      payee: 'SY1pay1',
+      ...overrides,
+    };
+  }
+
+  test('returns empty on empty inputs', () => {
+    expect(lookupMatches([], ['sys1qaaa'])).toEqual([]);
+    expect(lookupMatches([mn()], [])).toEqual([]);
+    expect(lookupMatches(null, ['sys1qaaa'])).toEqual([]);
+    expect(lookupMatches([mn()], null)).toEqual([]);
+  });
+
+  test('matches on votingaddress (case-insensitive)', () => {
+    const arr = [mn({ votingaddress: 'sys1qabc' })];
+    const out = lookupMatches(arr, ['SYS1QABC']);
+    expect(out).toHaveLength(1);
+    expect(out[0].votingaddress).toBe('sys1qabc');
+  });
+
+  test('drops MNs without a parsed outpoint', () => {
+    const arr = [
+      mn({ votingaddress: 'sys1qbad', collateralHash: null, collateralIndex: null }),
+      mn({ votingaddress: 'sys1qok' }),
+    ];
+    const out = lookupMatches(arr, ['sys1qbad', 'sys1qok']);
+    expect(out).toHaveLength(1);
+    expect(out[0].votingaddress).toBe('sys1qok');
+  });
+
+  test('projects only the subset the frontend needs', () => {
+    const arr = [
+      mn({
+        votingaddress: 'sys1qabc',
+        operatorPubKey: 'SHOULD_NOT_LEAK',
+        secretField: 'nope',
+      }),
+    ];
+    const out = lookupMatches(arr, ['sys1qabc']);
+    expect(out[0]).toEqual({
+      votingaddress: 'sys1qabc',
+      proTxHash: 'p1',
+      collateralHash: VALID_HASH,
+      collateralIndex: 0,
+      status: 'ENABLED',
+      address: '1.2.3.4:8369',
+      payee: 'SY1pay1',
+    });
+    expect(out[0].operatorPubKey).toBeUndefined();
+    expect(out[0].secretField).toBeUndefined();
+  });
+
+  test('a lookup of 3 addrs against 500 MNs returns only the 3 matches', () => {
+    const arr = Array.from({ length: 500 }, (_, i) =>
+      mn({ votingaddress: `sys1qv${i}`, collateralIndex: i })
+    );
+    const out = lookupMatches(arr, ['sys1qv4', 'sys1qv42', 'sys1qv499']);
+    expect(out.map((m) => m.votingaddress).sort()).toEqual([
+      'sys1qv4',
+      'sys1qv42',
+      'sys1qv499',
+    ]);
+  });
+});
+
+describe('classifyRpcError', () => {
+  test.each([
+    ['Failure to find masternode in list : abcd-0', 'mn_not_found'],
+    ['Failure to verify vote.', 'signature_invalid'],
+    ['Masternode voting too often', 'vote_too_often'],
+    ['Governance object not found', 'proposal_not_found'],
+    ['Invalid vote signal. Please using one of...', 'invalid_vote_signal'],
+    ['Invalid vote outcome. Please use one of...', 'invalid_vote_outcome'],
+    ['Malformed base64 encoding', 'signature_malformed'],
+    ['Already known valid vote', 'already_voted'],
+    ['some wholly unrecognised error', 'rpc_error'],
+    [undefined, 'rpc_error'],
+  ])('%s -> %s', (msg, expected) => {
+    expect(classifyRpcError(msg)).toBe(expected);
+  });
+});
+
+describe('relayVotes', () => {
+  const validated = {
+    proposalHash: VALID_HASH,
+    voteOutcome: 'yes',
+    voteSignal: 'funding',
+    time: NOW_S,
+    entries: [
+      { collateralHash: VALID_HASH_2, collateralIndex: 0, voteSig: SIG },
+      { collateralHash: VALID_HASH_2, collateralIndex: 1, voteSig: SIG },
+      { collateralHash: VALID_HASH_2, collateralIndex: 2, voteSig: SIG },
+    ],
+  };
+
+  test('happy path: all entries accepted', async () => {
+    const voteRaw = jest.fn().mockResolvedValue('Voted successfully');
+    const out = await relayVotes(voteRaw, validated);
+    expect(out.accepted).toBe(3);
+    expect(out.rejected).toBe(0);
+    expect(out.results.every((r) => r.ok)).toBe(true);
+    // voteRaw is called with the contract Core expects:
+    // (collateralHash, collateralIndex, proposalHash, signal, outcome, time, sigBase64)
+    for (let i = 0; i < 3; i++) {
+      expect(voteRaw).toHaveBeenNthCalledWith(
+        i + 1,
+        VALID_HASH_2,
+        i,
+        VALID_HASH,
+        'funding',
+        'yes',
+        NOW_S,
+        SIG
+      );
+    }
+  });
+
+  test('mixed: per-entry failures surface with codes, do not sink the batch', async () => {
+    const voteRaw = jest.fn().mockImplementation((_h, idx) => {
+      if (idx === 1) throw new Error('Failure to verify vote.');
+      if (idx === 2)
+        return Promise.reject(new Error('Masternode voting too often'));
+      return Promise.resolve('Voted successfully');
+    });
+    const out = await relayVotes(voteRaw, validated, { concurrency: 2 });
+    expect(out.accepted).toBe(1);
+    expect(out.rejected).toBe(2);
+    expect(out.results).toEqual([
+      { collateralHash: VALID_HASH_2, collateralIndex: 0, ok: true },
+      {
+        collateralHash: VALID_HASH_2,
+        collateralIndex: 1,
+        ok: false,
+        error: 'signature_invalid',
+      },
+      {
+        collateralHash: VALID_HASH_2,
+        collateralIndex: 2,
+        ok: false,
+        error: 'vote_too_often',
+      },
+    ]);
+  });
+
+  test('result ordering matches input ordering under concurrency', async () => {
+    // Staggered resolutions: entry 0 slow, entry 1 fast, entry 2 medium.
+    const voteRaw = jest.fn().mockImplementation(
+      (_h, idx) =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve('Voted successfully'), [30, 5, 15][idx])
+        )
+    );
+    const out = await relayVotes(voteRaw, validated, { concurrency: 3 });
+    expect(out.results.map((r) => r.collateralIndex)).toEqual([0, 1, 2]);
+  });
+
+  test('throws if voteRaw is missing', async () => {
+    await expect(relayVotes(undefined, validated)).rejects.toThrow(
+      /voteRaw function is required/
+    );
+  });
+});

--- a/middleware/rateLimit.js
+++ b/middleware/rateLimit.js
@@ -32,6 +32,21 @@ function registerKey(req) {
   return `register|${ipBucket(req)}`;
 }
 
+// Per-user bucket for /gov/vote. IP alone is wrong here: a shared-IP
+// office can legitimately vote from many accounts in one hour, and a
+// user on a mobile IPv6 prefix can churn through addresses faster
+// than the register bucket's /56 masking catches. We bucket by the
+// authenticated user.id (set by sessionMw.requireAuth before this
+// limiter runs) and fall back to IP for defense in depth — a
+// pre-auth miss here should never happen in production, but the
+// fallback keeps the limiter safe if someone mounts it without the
+// auth middleware.
+function voteKey(req) {
+  const uid = req.user && req.user.id != null ? String(req.user.id) : null;
+  if (uid) return `vote|u${uid}`;
+  return `vote|ip|${ipBucket(req)}`;
+}
+
 function loginLimiter() {
   return rateLimit({
     windowMs: 15 * MINUTE,
@@ -54,6 +69,22 @@ function registerLimiter() {
   });
 }
 
+// /gov/vote: 60 POSTs per hour per user. A proposal cycle has a few
+// dozen active proposals; a user who votes on every proposal twice
+// (e.g. changed their mind) still fits comfortably. Each request
+// carries up to MAX_VOTE_ENTRIES entries, so the effective ceiling
+// is ample without inviting abuse.
+function voteLimiter() {
+  return rateLimit({
+    windowMs: 60 * MINUTE,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: voteKey,
+    message: { error: 'too_many_vote_requests' },
+  });
+}
+
 function disabled() {
   return (_req, _res, next) => next();
 }
@@ -61,8 +92,10 @@ function disabled() {
 module.exports = {
   loginLimiter,
   registerLimiter,
+  voteLimiter,
   disabled,
   // Exported for direct unit testing.
   loginKey,
   registerKey,
+  voteKey,
 };

--- a/middleware/rateLimit.test.js
+++ b/middleware/rateLimit.test.js
@@ -1,10 +1,13 @@
 const {
   loginKey,
   registerKey,
+  voteKey,
 } = require('./rateLimit');
 
-function mk(body, ip = '1.2.3.4') {
-  return { ip, body };
+function mk(body, ip = '1.2.3.4', user) {
+  const req = { ip, body };
+  if (user) req.user = user;
+  return req;
 }
 
 describe('rate-limit key generators', () => {
@@ -58,6 +61,26 @@ describe('rate-limit key generators', () => {
       const a = registerKey(mk({}, '2001:db8:1234:5600::1'));
       const b = registerKey(mk({}, '2001:db8:1234:56ff::1'));
       expect(a).toBe(b);
+    });
+  });
+
+  describe('voteKey', () => {
+    test('buckets by authenticated user.id when present', () => {
+      const a = voteKey(mk({}, '1.2.3.4', { id: 42 }));
+      const b = voteKey(mk({}, '9.9.9.9', { id: 42 }));
+      expect(a).toBe(b);
+      expect(a).toBe('vote|u42');
+    });
+
+    test('two distinct users on the same IP get distinct buckets', () => {
+      const a = voteKey(mk({}, '1.2.3.4', { id: 1 }));
+      const b = voteKey(mk({}, '1.2.3.4', { id: 2 }));
+      expect(a).not.toBe(b);
+    });
+
+    test('falls back to IP bucket when the user is missing (defense in depth)', () => {
+      const a = voteKey(mk({}, '1.2.3.4'));
+      expect(a).toMatch(/^vote\|ip\|1\.2\.3\.4$/);
     });
   });
 });

--- a/routes/gov.js
+++ b/routes/gov.js
@@ -1,0 +1,139 @@
+const express = require('express');
+
+const {
+  validateLookupBody,
+  validateVoteBody,
+  lookupMatches,
+  relayVotes,
+} = require('../lib/gov');
+
+// Governance HTTP surface.
+//
+//   POST /gov/mns/lookup  -> { matches: [{ votingaddress, proTxHash,
+//                                          collateralHash, collateralIndex,
+//                                          status, address, payee }, ...] }
+//   POST /gov/vote        -> { accepted, rejected, results: [{
+//                                   collateralHash, collateralIndex,
+//                                   ok, error? }, ...] }
+//
+// Both endpoints are authenticated + CSRF-protected. /gov/vote
+// additionally sits behind a per-user rate limiter. The signing
+// happens client-side (voteSigner.js); we never see the WIF and we
+// never generate signatures ourselves.
+//
+// Injectables (for testability):
+//   - masternodesProvider: () => Array of enriched MN objects from
+//     services/masternodeTracker. Called fresh on each request so the
+//     tracker's 10s refresh is visible without our needing to import
+//     the dataStore module directly (the production wiring just
+//     returns `require('../data/dataStore').masternodesArr`, i.e.
+//     reads the LIVE property that the tracker reassigns — avoid
+//     destructuring the array into a stale reference).
+//   - voteRaw: (collHash, collIdx, govHash, signal, outcome, time, sigB64)
+//              => Promise<string>. Production passes the syscoin-js
+//              wrapper; tests pass a mock.
+//   - nowMs: injectable clock for deterministic time-window tests.
+//   - voteLimiter: an express-rate-limit middleware (or a no-op in
+//                  tests). Mounted only on POST /gov/vote.
+
+function createGovRouter({
+  masternodesProvider,
+  voteRaw,
+  sessionMw,
+  csrfMw,
+  voteLimiter = (_req, _res, next) => next(),
+  nowMs = () => Date.now(),
+}) {
+  if (typeof masternodesProvider !== 'function') {
+    throw new Error('createGovRouter: masternodesProvider is required');
+  }
+  if (typeof voteRaw !== 'function') {
+    throw new Error('createGovRouter: voteRaw is required');
+  }
+  if (!sessionMw || typeof sessionMw.requireAuth !== 'function') {
+    throw new Error('createGovRouter: sessionMw is required');
+  }
+  if (!csrfMw || typeof csrfMw.require !== 'function') {
+    throw new Error('createGovRouter: csrfMw is required');
+  }
+
+  const router = express.Router();
+
+  // -------------------------------------------------------------------
+  // POST /gov/mns/lookup
+  //
+  // Input : { votingAddresses: string[] }
+  // Output: { matches: [...] }
+  //
+  // Semantics: "given these addresses, which of them correspond to a
+  // currently-known, usable masternode?". Typos / unknown addresses
+  // are silently dropped (200 OK with fewer results) rather than
+  // 400'd, because the frontend pipes in every address from the
+  // user's vault and a bad one there isn't a request-shape bug.
+  // -------------------------------------------------------------------
+  router.post(
+    '/mns/lookup',
+    sessionMw.requireAuth,
+    csrfMw.require,
+    (req, res) => {
+      const parsed = validateLookupBody(req.body);
+      if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+      const mnArr = masternodesProvider() || [];
+      const matches = lookupMatches(mnArr, parsed.votingAddresses);
+      return res.json({ matches });
+    }
+  );
+
+  // -------------------------------------------------------------------
+  // POST /gov/vote
+  //
+  // Input: {
+  //   proposalHash: 64-hex,
+  //   voteOutcome:  "yes" | "no" | "abstain",
+  //   voteSignal:   "funding",                // PR 5 scope
+  //   time:         unix-seconds,
+  //   entries: [{
+  //     collateralHash:  64-hex,
+  //     collateralIndex: uint,
+  //     voteSig:         base64(65 bytes)     // client-signed
+  //   }, ...]
+  // }
+  //
+  // Output: 200 { accepted, rejected, results: [...] } — returns 200
+  // even if SOME entries failed, because the normal case with many MNs
+  // is "most succeeded, one got an expected-and-recoverable error"
+  // (e.g. vote_too_often). Per-entry {ok, error} lets the UI render a
+  // mixed outcome without us picking a single HTTP status that'd
+  // misrepresent it.
+  //
+  // Rejections before fan-out (validation, rate limit, auth) DO use
+  // 4xx because those are request-shape problems, not chain-level
+  // outcomes.
+  // -------------------------------------------------------------------
+  router.post(
+    '/vote',
+    sessionMw.requireAuth,
+    csrfMw.require,
+    voteLimiter,
+    async (req, res) => {
+      const parsed = validateVoteBody(req.body, { nowMs: nowMs() });
+      if (!parsed.ok) return res.status(400).json({ error: parsed.error });
+      try {
+        const out = await relayVotes(voteRaw, parsed);
+        return res.json(out);
+      } catch (err) {
+        // relayVotes only rejects on wiring bugs (no voteRaw passed).
+        // A real RPC failure on an individual entry is surfaced in
+        // results[i].error, not as an exception. So any throw here is
+        // a 500-class problem.
+        // eslint-disable-next-line no-console
+        console.error('[POST /gov/vote] unexpected', err);
+        return res.status(500).json({ error: 'internal' });
+      }
+    }
+  );
+
+  return router;
+}
+
+module.exports = { createGovRouter };

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const csvParserRoute = require('./routes/csvParser');
 const mnListRoute = require('./routes/mnList');
 const mnSearchRoute = require('./routes/mnSearch');
 
-// New authenticated subsystem (auth + vault).
+// New authenticated subsystem (auth + vault + gov).
 const { openDatabase } = require('./lib/db');
 const { createMailer } = require('./lib/mailer');
 const { selectMailTransport } = require('./lib/mailTransport');
@@ -27,6 +27,8 @@ const {
   finalizeSessionMw,
   mountAuthAndVault,
 } = require('./lib/appFactory');
+const dataStore = require('./data/dataStore');
+const { client, rpcServices } = require('./services/rpcClient');
 
 const app = express();
 
@@ -101,6 +103,24 @@ mountAuthAndVault(app, {
     process.env.FRONTEND_URL ||
     process.env.CORS_ORIGIN ||
     'http://localhost:3000',
+  // Read the live tracker array fresh on every call rather than
+  // snapshotting it here — the tracker REASSIGNS `masternodesArr`
+  // every 10s (`data.masternodesArr = []`), so a captured reference
+  // would go stale after the first refresh. `dataStore.masternodesArr`
+  // is a property access and therefore always returns the current value.
+  masternodesProvider: () => dataStore.masternodesArr,
+  voteRaw: (collateralHash, collateralIndex, governanceHash, signal, outcome, time, voteSig) =>
+    rpcServices(client.callRpc)
+      .voteRaw(
+        collateralHash,
+        collateralIndex,
+        governanceHash,
+        signal,
+        outcome,
+        time,
+        voteSig
+      )
+      .call(true),
 });
 
 // -----------------------------------------------------------------------------

--- a/server.js
+++ b/server.js
@@ -59,16 +59,20 @@ app.use(cookieParser());
 
 // -----------------------------------------------------------------------------
 // CORS: legacy public data routes keep `origin: *` so existing third-party
-// consumers don't break. Auth and vault use credentialed CORS pinned to the
-// SPA origin (browsers reject `*` with credentials).
+// consumers don't break. Auth, vault, and gov use credentialed CORS pinned
+// to the SPA origin (browsers reject `*` with credentials). /gov is the
+// authenticated voting surface; it carries cookies + the X-CSRF-Token
+// header and MUST go through `authCors` or browsers will block the
+// preflight.
 // -----------------------------------------------------------------------------
 const legacyCors = cors({ origin: '*', optionsSuccessStatus: 200 });
 const authCors = cors({
   origin: process.env.CORS_ORIGIN || 'http://localhost:3000',
   credentials: true,
 });
+const CREDENTIALED_PREFIXES = ['/auth', '/vault', '/gov'];
 app.use((req, res, next) => {
-  if (req.path.startsWith('/auth') || req.path.startsWith('/vault')) {
+  if (CREDENTIALED_PREFIXES.some((p) => req.path.startsWith(p))) {
     return authCors(req, res, next);
   }
   return legacyCors(req, res, next);
@@ -93,7 +97,11 @@ const mailer = createMailer({
 });
 const services = finalizeSessionMw(buildServices({ db }));
 
-app.use(['/auth', '/vault'], services.sessionMw.parse);
+// Session parsing must cover every route that reads `req.user`. /gov
+// uses `requireAuth` in its router; without parse running here first
+// `req.user` would always be undefined and every authenticated caller
+// would see a 401.
+app.use(['/auth', '/vault', '/gov'], services.sessionMw.parse);
 
 mountAuthAndVault(app, {
   services,

--- a/server.js
+++ b/server.js
@@ -64,15 +64,25 @@ app.use(cookieParser());
 // authenticated voting surface; it carries cookies + the X-CSRF-Token
 // header and MUST go through `authCors` or browsers will block the
 // preflight.
+//
+// CRITICAL: the prefix match MUST be on a path boundary — i.e. "exactly
+// `/gov`" or "starts with `/gov/`". A naive `startsWith('/gov')` also
+// catches the legacy public endpoints `/govlist` and `/govbyhash`
+// (routes/governance.js), which are historically served under
+// `origin: '*'` and must keep working for third-party consumers that
+// are not on the configured CORS_ORIGIN. Same argument applies to
+// `/auth` / `/vault`, though today those prefixes have no legacy
+// collisions; we enforce the boundary everywhere to stay safe as the
+// legacy surface evolves.
 // -----------------------------------------------------------------------------
 const legacyCors = cors({ origin: '*', optionsSuccessStatus: 200 });
 const authCors = cors({
   origin: process.env.CORS_ORIGIN || 'http://localhost:3000',
   credentials: true,
 });
-const CREDENTIALED_PREFIXES = ['/auth', '/vault', '/gov'];
+const { isCredentialedPath } = require('./lib/credentialedPaths');
 app.use((req, res, next) => {
-  if (CREDENTIALED_PREFIXES.some((p) => req.path.startsWith(p))) {
+  if (isCredentialedPath(req.path)) {
     return authCors(req, res, next);
   }
   return legacyCors(req, res, next);

--- a/services/masternodeTracker.js
+++ b/services/masternodeTracker.js
@@ -17,6 +17,23 @@ for (let i = 255; i >= 0; i--) {
   data.mapFills["heat" + i] = rgbToHex(0, 255 - i, 255);
 }
 
+// Parse the outer dict key that Syscoin's `masternode_list` returns
+// for each MN. Core serialises it as `COutPoint::ToStringShort()` =
+// `"<txid>-<n>"` (see src/primitives/transaction.cpp). We split on
+// the LAST dash so a hypothetical future change that embeds a dash
+// inside the hash half still round-trips; txid is always 64 hex
+// chars today, so this is belt-and-braces.
+function parseOutpointKey(key) {
+  if (typeof key !== "string") return null;
+  const i = key.lastIndexOf("-");
+  if (i <= 0 || i === key.length - 1) return null;
+  const hash = key.slice(0, i);
+  const n = Number(key.slice(i + 1));
+  if (!/^[0-9a-fA-F]{64}$/.test(hash)) return null;
+  if (!Number.isInteger(n) || n < 0 || n > 0xffffffff) return null;
+  return { collateralHash: hash.toLowerCase(), collateralIndex: n };
+}
+
 setInterval(() => {
   rpcServices(client.callRpc).masternode_list().call().then(masternodes => {
 
@@ -25,6 +42,18 @@ setInterval(() => {
 
     for (let key in masternodes) {
       const node = masternodes[key];
+      // Additive enrichment: Syscoin Core's `masternode_list` values
+      // don't carry `collateralHash`/`collateralIndex` directly, but
+      // the object's outer key IS the outpoint (COutPoint::ToStringShort
+      // => "<txid>-<n>"). Preserving that here lets the /gov endpoints
+      // relay votes without a second round-trip per MN. No existing
+      // consumer (mnSearch, mnList, mnStats) reads these fields, so
+      // adding them is strictly additive.
+      const outpoint = parseOutpointKey(key);
+      if (outpoint) {
+        node.collateralHash = outpoint.collateralHash;
+        node.collateralIndex = outpoint.collateralIndex;
+      }
       data.masternodesArr.push(node);
 
       if (geoip.lookup(node.address.split(':')[0]) != null) {

--- a/tests/gov.routes.test.js
+++ b/tests/gov.routes.test.js
@@ -1,0 +1,385 @@
+const request = require('supertest');
+const { buildTestApp } = require('./helpers/buildTestApp');
+
+const SAMPLE_AUTH =
+  'a4f8b3c1d9e7f2a5b1c6d8e4f7a9b2c5d1e8f4a7b3c9d5e1f6a2b8c4d7e3f5a9';
+
+// Deterministic 64-hex constants we can reuse across cases.
+const H1 = 'a'.repeat(64);
+const H2 = 'b'.repeat(64);
+const H3 = 'c'.repeat(64);
+
+// 65 raw bytes = 88 base64 chars with padding. Real signatures are
+// produced client-side; for HTTP plumbing tests we only need
+// something that passes validateVoteBody.
+const SIG = 'A'.repeat(86) + '==';
+
+function extractCookies(res) {
+  const raw = res.headers['set-cookie'] || [];
+  const map = {};
+  for (const c of raw) {
+    const [pair] = c.split(';');
+    const [k, v] = pair.split('=');
+    map[k] = v;
+  }
+  return map;
+}
+
+// Build a logged-in supertest agent on top of a test app. We register,
+// verify, and log in a single user; the returned CSRF token is read
+// from the `csrf` cookie emitted by /auth/login.
+async function loggedInAgent(ctx, email = 'user@example.com') {
+  const agent = request.agent(ctx.app);
+  await agent
+    .post('/auth/register')
+    .send({ email, authHash: SAMPLE_AUTH });
+  const token = ctx.mailer.outbox
+    .find((m) => m.to === email)
+    .html.match(/token=([0-9a-f]{64})/)[1];
+  await agent.post('/auth/verify-email').send({ token });
+  const loginRes = await agent
+    .post('/auth/login')
+    .send({ email, authHash: SAMPLE_AUTH });
+  const csrf = extractCookies(loginRes).csrf;
+  return { agent, csrf };
+}
+
+// The production masternodesProvider reads `dataStore.masternodesArr`
+// live on every call so the tracker's 10s refresh is visible without
+// route code holding a stale reference. Our tests mirror that with a
+// mutable `state` object whose `masternodes` property can be swapped
+// between requests.
+function buildApp({ masternodes = [], voteRaw } = {}) {
+  const state = { masternodes };
+  const calls = [];
+  const rawFn =
+    voteRaw ||
+    (async (...args) => {
+      calls.push(args);
+      return 'Voted successfully';
+    });
+  const ctx = buildTestApp({
+    masternodesProvider: () => state.masternodes,
+    voteRaw: rawFn,
+  });
+  return { ctx, state, calls };
+}
+
+describe('POST /gov/mns/lookup', () => {
+  let ctx;
+  let state;
+
+  beforeEach(() => {
+    ({ ctx, state } = buildApp({
+      masternodes: [
+        {
+          votingaddress: 'sys1qalice',
+          proTxHash: H1,
+          collateralHash: H2,
+          collateralIndex: 0,
+          status: 'ENABLED',
+          address: '1.2.3.4:8369',
+          payee: 'sys1qpayeeA',
+        },
+        {
+          votingaddress: 'sys1qbob',
+          proTxHash: H2,
+          collateralHash: H3,
+          collateralIndex: 1,
+          status: 'ENABLED',
+          address: '5.6.7.8:8369',
+          payee: 'sys1qpayeeB',
+        },
+      ],
+    }));
+  });
+
+  afterEach(() => {
+    ctx.db.close();
+  });
+
+  test('401 when unauthenticated', async () => {
+    const res = await request(ctx.app)
+      .post('/gov/mns/lookup')
+      .send({ votingAddresses: ['sys1qalice'] });
+    expect(res.status).toBe(401);
+  });
+
+  test('403 csrf_missing when authenticated without CSRF token', async () => {
+    const { agent } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/mns/lookup')
+      .send({ votingAddresses: ['sys1qalice'] });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('csrf_missing');
+  });
+
+  test('returns matches for known voting addresses', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/mns/lookup')
+      .set('X-CSRF-Token', csrf)
+      .send({ votingAddresses: ['sys1qalice', 'sys1qbob'] });
+    expect(res.status).toBe(200);
+    expect(res.body.matches).toHaveLength(2);
+    const v = res.body.matches.map((m) => m.votingaddress).sort();
+    expect(v).toEqual(['sys1qalice', 'sys1qbob']);
+    // Projection must include collateral fields so the client can
+    // feed them straight into POST /gov/vote without a second lookup.
+    const alice = res.body.matches.find(
+      (m) => m.votingaddress === 'sys1qalice'
+    );
+    expect(alice.collateralHash).toBe(H2);
+    expect(alice.collateralIndex).toBe(0);
+    expect(alice.status).toBe('ENABLED');
+  });
+
+  test('unknown addresses are silently dropped (no 400)', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/mns/lookup')
+      .set('X-CSRF-Token', csrf)
+      .send({
+        votingAddresses: ['sys1qalice', 'sys1qwho', 'sys1qnope'],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.matches).toHaveLength(1);
+    expect(res.body.matches[0].votingaddress).toBe('sys1qalice');
+  });
+
+  test('empty array returns empty matches (200)', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/mns/lookup')
+      .set('X-CSRF-Token', csrf)
+      .send({ votingAddresses: [] });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ matches: [] });
+  });
+
+  test('reflects mutations to the tracker between requests', async () => {
+    // The router takes `masternodesProvider` as a callable, not a
+    // snapshot. This test guarantees that a tracker refresh visible
+    // to the provider is visible to a subsequent request — i.e. we
+    // aren't caching the array.
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const before = await agent
+      .post('/gov/mns/lookup')
+      .set('X-CSRF-Token', csrf)
+      .send({ votingAddresses: ['sys1qcarol'] });
+    expect(before.body.matches).toEqual([]);
+
+    state.masternodes = [
+      ...state.masternodes,
+      {
+        votingaddress: 'sys1qcarol',
+        proTxHash: 'd'.repeat(64),
+        collateralHash: 'e'.repeat(64),
+        collateralIndex: 2,
+        status: 'ENABLED',
+        address: '9.9.9.9:8369',
+        payee: 'sys1qpayeeC',
+      },
+    ];
+
+    const after = await agent
+      .post('/gov/mns/lookup')
+      .set('X-CSRF-Token', csrf)
+      .send({ votingAddresses: ['sys1qcarol'] });
+    expect(after.body.matches).toHaveLength(1);
+    expect(after.body.matches[0].collateralIndex).toBe(2);
+  });
+
+  test('rejects non-array votingAddresses with 400 invalid_body', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/mns/lookup')
+      .set('X-CSRF-Token', csrf)
+      .send({ votingAddresses: 'sys1qalice' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_body');
+  });
+});
+
+describe('POST /gov/vote', () => {
+  function validVoteBody(overrides = {}) {
+    return {
+      proposalHash: H1,
+      voteOutcome: 'yes',
+      voteSignal: 'funding',
+      time: Math.floor(Date.now() / 1000),
+      entries: [
+        { collateralHash: H2, collateralIndex: 0, voteSig: SIG },
+        { collateralHash: H3, collateralIndex: 1, voteSig: SIG },
+      ],
+      ...overrides,
+    };
+  }
+
+  test('401 when unauthenticated', async () => {
+    const { ctx } = buildApp();
+    try {
+      const res = await request(ctx.app)
+        .post('/gov/vote')
+        .send(validVoteBody());
+      expect(res.status).toBe(401);
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('403 csrf_missing when authenticated without CSRF token', async () => {
+    const { ctx } = buildApp();
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.post('/gov/vote').send(validVoteBody());
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('csrf_missing');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('relays per-entry votes via voteRaw and returns per-entry results', async () => {
+    const { ctx, calls } = buildApp();
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const body = validVoteBody();
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(body);
+      expect(res.status).toBe(200);
+      expect(res.body.accepted).toBe(2);
+      expect(res.body.rejected).toBe(0);
+      expect(res.body.results).toHaveLength(2);
+      expect(res.body.results.every((r) => r.ok)).toBe(true);
+
+      // voteRaw arg order must match Core's voteraw RPC:
+      // (collateralHash, collateralIndex, govHash, signal, outcome, time, sig)
+      expect(calls).toHaveLength(2);
+      const [cHash, cIdx, gHash, signal, outcome, time, sig] = calls[0];
+      expect(cHash).toBe(H2);
+      expect(cIdx).toBe(0);
+      expect(gHash).toBe(H1);
+      expect(signal).toBe('funding');
+      expect(outcome).toBe('yes');
+      expect(time).toBe(body.time);
+      expect(sig).toBe(SIG);
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('mixed success/failure returns 200 with per-entry errors', async () => {
+    const voteRaw = jest
+      .fn()
+      .mockResolvedValueOnce('Voted successfully')
+      .mockRejectedValueOnce(new Error('Masternode voting too often'));
+    const { ctx } = buildApp({ voteRaw });
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(validVoteBody());
+      expect(res.status).toBe(200);
+      expect(res.body.accepted).toBe(1);
+      expect(res.body.rejected).toBe(1);
+      const failing = res.body.results.find((r) => !r.ok);
+      // Core's error message is mapped to a stable UI code.
+      expect(failing.error).toBe('vote_too_often');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('unknown RPC errors collapse to rpc_error (no leakage of node internals)', async () => {
+    const voteRaw = jest
+      .fn()
+      .mockRejectedValue(new Error('random internal RPC blowup #42'));
+    const { ctx } = buildApp({ voteRaw });
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(validVoteBody());
+      expect(res.status).toBe(200);
+      expect(res.body.results.every((r) => r.error === 'rpc_error')).toBe(
+        true
+      );
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('400 invalid_proposal_hash when proposalHash is malformed', async () => {
+    const { ctx } = buildApp();
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(validVoteBody({ proposalHash: 'not-hex' }));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_proposal_hash');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('400 unsupported_vote_signal when voteSignal is not "funding"', async () => {
+    // PR 5 enforces funding-only because other signals need the
+    // operator BLS key, which the vault does not hold.
+    const { ctx } = buildApp();
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(validVoteBody({ voteSignal: 'valid' }));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('unsupported_vote_signal');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('400 no_entries when entries is empty', async () => {
+    const { ctx } = buildApp();
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(validVoteBody({ entries: [] }));
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('no_entries');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('400 on duplicate (collateralHash,index) entries', async () => {
+    const { ctx } = buildApp();
+    try {
+      const { agent, csrf } = await loggedInAgent(ctx);
+      const res = await agent
+        .post('/gov/vote')
+        .set('X-CSRF-Token', csrf)
+        .send(
+          validVoteBody({
+            entries: [
+              { collateralHash: H2, collateralIndex: 0, voteSig: SIG },
+              { collateralHash: H2, collateralIndex: 0, voteSig: SIG },
+            ],
+          })
+        );
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/^duplicate_entry:/);
+    } finally {
+      ctx.db.close();
+    }
+  });
+});

--- a/tests/gov.routes.test.js
+++ b/tests/gov.routes.test.js
@@ -12,7 +12,10 @@ const H3 = 'c'.repeat(64);
 // 65 raw bytes = 88 base64 chars with padding. Real signatures are
 // produced client-side; for HTTP plumbing tests we only need
 // something that passes validateVoteBody.
-const SIG = 'A'.repeat(86) + '==';
+// Canonical 65-byte base64 sig (all zero bytes). See gov.test.js for
+// the full rationale; short version: "A".repeat(86)+"==" decodes to
+// 64 bytes and is rejected by the strict validator.
+const SIG = Buffer.alloc(65).toString('base64');
 
 function extractCookies(res) {
   const raw = res.headers['set-cookie'] || [];


### PR DESCRIPTION
## Summary

Adds the authenticated `/gov/*` surface that pairs with the upcoming client-side vote signer, so Masternode operators can relay votes directly from the browser without SSHing into a node. Every entry is relayed through Core's `voteraw` RPC; the endpoint fans the batch and returns per-entry `{ ok, error }` so the UI can reconcile partial failures.

### What's new

- `POST /gov/mns/lookup` (auth + CSRF) — takes a list of voting addresses from the user's vault and returns the matching masternodes (proTxHash, collateralHash, collateralIndex, status, network address, payee). Unknown addresses are silently dropped so vaults with more keys than live MNs work naturally.
- `POST /gov/vote` (auth + CSRF + per-user rate limit) — accepts a batch of `{ collateralHash, collateralIndex, voteSig }` tuples plus `(proposalHash, voteOutcome, voteSignal, time)` shared across the batch, fans out to `voteraw`, aggregates results.
- Masternode tracker (`services/masternodeTracker.js`) now parses `collateralHash` / `collateralIndex` from Core's outpoint key, so the lookup endpoint can return them without a second RPC.
- Rate-limit middleware: new `voteKey` generator + `voteLimiter` that buckets by authenticated user id, falling back to IP for the (rare) unauthenticated edge. Sized to block gov-spam without throttling legitimate operators.
- App factory: dependency-injected `masternodesProvider` (live from `dataStore.masternodesArr`) and `voteRaw` (wrapping `rpcServices(callRpc).voteRaw(...)`).

### Why dependency-inject `voteRaw` and `masternodesProvider`?

Keeps `lib/gov.js` pure-functional and trivially testable with fake providers — the route tests never touch Core or the real tracker cache. Production wiring happens once in `server.js`.

### Byte-level care around voteraw

The route validates every field before calling Core:

- `collateralHash` — 64-char lowercase hex
- `collateralIndex` — non-negative integer
- `voteSig` — base64 decoding to exactly 65 bytes (the recoverable ECDSA format Core expects)
- `voteSignal` — currently `funding` only (expandable)
- `voteOutcome` — `yes` | `no` | `abstain`
- `time` — positive integer seconds-since-epoch

Invalid shapes are rejected with stable error codes the frontend can switch on (`invalid_collateral_hash`, `invalid_vote_signal`, etc.) rather than HTTP-status guessing.

## Test plan

- [x] Unit — `lib/gov.test.js`: lookup filtering, vote fan-out, validation matrix, Core error mapping
- [x] Routes — `tests/gov.routes.test.js`: auth, CSRF double-submit, successful batches, mixed success/failure relay, unknown addresses, rate-limit 429, every 400/401/403 branch
- [x] Rate limit — `middleware/rateLimit.test.js`: new `voteKey` bucketing by user id with IP fallback
- [x] Full suite: **241 tests / 19 suites passing**

## Notes for review

- The tracker parsing change is additive — existing consumers still get the same fields; `collateralHash`/`collateralIndex` are new optional properties on each row.
- This PR only lands the server-side surface. The client-side signer + Governance-page UI come in the sysnode-info companion PR.

@codex review

Made with [Cursor](https://cursor.com)