### PR TITLE
feat(governance): Pali PSBT path for 150 SYS collateral (PR10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,23 @@ SYSCOIN_RPC_PORT=8370
 SYSCOIN_RPC_USER=
 SYSCOIN_RPC_PASS=
 SYSCOIN_RPC_LOG_LEVEL=error
+
+# Governance "Pay with Pali" path. Both variables MUST be set for the
+# server to build a 150-SYS collateral PSBT from a connected Pali
+# account; either blank disables the /collateral/psbt route (the FE
+# feature-detects and keeps the manual CLI fallback visible).
+#
+# SYSCOIN_NETWORK: 'mainnet' | 'testnet'. Pinned chain — must match
+#                  the SYSCOIN_RPC_* node above AND the Blockbook URL
+#                  below. The PSBT builder uses this to pick the
+#                  correct xpub prefix (zpub / vpub) and bech32 HRP
+#                  (sys / tsys) and to reject Pali users on the wrong
+#                  network before any fees could be burned.
+#
+# SYSCOIN_BLOCKBOOK_URL: xpub-UTXO indexer used by syscoinjs-lib.
+#                  Trailing slashes are tolerated; the library appends
+#                  its own API paths.
+#                   Mainnet : https://blockbook.syscoin.org/
+#                   Testnet : https://blockbook-dev.syscoin.org/
+SYSCOIN_NETWORK=
+SYSCOIN_BLOCKBOOK_URL=

--- a/lib/appFactory.js
+++ b/lib/appFactory.js
@@ -104,6 +104,10 @@ function mountAuthAndVault(
     // falls back to the manual CLI flow.
     governanceNetworkInfo = null,
     buildCollateralPsbt = null,
+    // Optional: live guard that cross-checks SYSCOIN_NETWORK against
+    // the actual RPC chain. See routes/govProposals.js for the
+    // contract. Pass-through only.
+    paliChainGuard = null,
   }
 ) {
   if (!services.sessionMw) finalizeSessionMw(services);
@@ -193,6 +197,7 @@ function mountAuthAndVault(
         now,
         networkInfo: governanceNetworkInfo,
         buildCollateralPsbt,
+        paliChainGuard,
       })
     );
   }

--- a/lib/appFactory.js
+++ b/lib/appFactory.js
@@ -95,6 +95,15 @@ function mountAuthAndVault(
     // Only the subset actually consumed by each route/dispatcher is
     // used, so test wiring can mock sparsely.
     proposalRpc = null,
+    // Optional: info about which chain this backend is pinned to, and
+    // an (already-wired) Pali collateral-PSBT builder. Both flow
+    // straight through to createGovProposalsRouter — see the big
+    // doc-comment there. Leaving either null disables the "Pay with
+    // Pali" path server-side (the /collateral/psbt route returns 503
+    // and /network reports paliPathEnabled=false), so the FE cleanly
+    // falls back to the manual CLI flow.
+    governanceNetworkInfo = null,
+    buildCollateralPsbt = null,
   }
 ) {
   if (!services.sessionMw) finalizeSessionMw(services);
@@ -182,6 +191,8 @@ function mountAuthAndVault(
         rpc: proposalRpc,
         runAtomic: services.runAtomic,
         now,
+        networkInfo: governanceNetworkInfo,
+        buildCollateralPsbt,
       })
     );
   }

--- a/lib/paliChainGuard.js
+++ b/lib/paliChainGuard.js
@@ -1,0 +1,208 @@
+'use strict';
+
+// paliChainGuard — cross-check operator-declared SYSCOIN_NETWORK
+// against the actual chain behind SYSCOIN_RPC_*.
+// ---------------------------------------------------------------
+// Motivation (Codex PR10 review): the PSBT builder trusts the
+// operator's `SYSCOIN_NETWORK` env verbatim to pick xpub/HRP rules.
+// If the RPC node it's paired with is on the OTHER chain (common
+// mistake: "I repointed the RPC node but forgot to flip the env"),
+// users can broadcast/burn 150 SYS on chain A while the dispatcher
+// watches chain B → submission fails as `collateral_not_found`
+// after 6 confirmations, 150 SYS is gone.
+//
+// The guard probes `getblockchaininfo().chain` once the RPC node is
+// reachable and compares to the declared chain. Mismatch is
+// permanent — it means the operator's configuration is wrong, and
+// the only correct recovery is to fix the env and restart. We
+// refuse to serve the Pali path for the rest of the process's life
+// in that case. RPC-unreachable is transient — we retry with
+// bounded exponential backoff so a late-starting RPC node doesn't
+// leave the Pali path disabled forever.
+//
+// States:
+//   'unverified' — initial; probe hasn't completed or hasn't started
+//   'verified'   — probe succeeded AND actual chain matches declared
+//   'mismatch'   — probe succeeded AND chains differ (terminal)
+//   'rpc_down'   — probe threw; we're retrying
+//
+// Only 'verified' opens the Pali path. Everything else disables it.
+
+const DEFAULT_INITIAL_DELAY_MS = 30 * 1000; // 30s after boot
+const DEFAULT_RETRY_MIN_MS = 5 * 1000;
+const DEFAULT_RETRY_MAX_MS = 5 * 60 * 1000;
+const DEFAULT_BACKOFF_FACTOR = 2;
+
+function noopLog() {}
+
+// Translate whatever `getblockchaininfo.chain` returns to the same
+// 'main' | 'test' vocabulary we use for `declaredChain` in
+// server.js. Syscoin Core returns 'main' for mainnet and 'test'
+// for the UTXO testnet (matches Bitcoin Core's convention);
+// 'regtest' / 'signet' are not supported by our deploy but we
+// surface them so the mismatch log is actionable.
+function normalizeChainString(s) {
+  if (typeof s !== 'string') return null;
+  const t = s.trim().toLowerCase();
+  if (t === 'main' || t === 'test' || t === 'regtest' || t === 'signet') {
+    return t;
+  }
+  return null;
+}
+
+function createPaliChainGuard({
+  declaredChain,
+  fetchActualChain,
+  log = noopLog,
+  scheduler = { setTimeout, clearTimeout },
+  initialDelayMs = DEFAULT_INITIAL_DELAY_MS,
+  retryMinMs = DEFAULT_RETRY_MIN_MS,
+  retryMaxMs = DEFAULT_RETRY_MAX_MS,
+  backoffFactor = DEFAULT_BACKOFF_FACTOR,
+} = {}) {
+  if (typeof fetchActualChain !== 'function') {
+    throw new Error('createPaliChainGuard: fetchActualChain is required');
+  }
+
+  // If the caller never declared a chain (i.e. Pali path wasn't
+  // configured at all), we return a guard that is permanently
+  // "unconfigured". Callers then fall through to the existing
+  // `pali_path_disabled` response. We keep a real object rather
+  // than null so router code doesn't have to null-check every
+  // caller site.
+  const declared = normalizeChainString(declaredChain);
+
+  let status = declared ? 'unverified' : 'mismatch';
+  let reason = declared ? null : 'pali_not_configured';
+  let actualChain = null;
+  let attempts = 0;
+  let timer = null;
+  let stopped = false;
+
+  function clearTimer() {
+    if (timer) {
+      scheduler.clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function schedule(delayMs) {
+    if (stopped) return;
+    clearTimer();
+    // Unref so the guard never keeps the process alive on its own.
+    // Node's setTimeout returns a Timeout object with .unref() in
+    // production; in tests the scheduler injected may return a
+    // plain id, so we feature-detect.
+    const t = scheduler.setTimeout(runOnce, delayMs);
+    if (t && typeof t.unref === 'function') t.unref();
+    timer = t;
+  }
+
+  function nextRetryDelay() {
+    const exp = Math.min(
+      retryMaxMs,
+      retryMinMs * Math.pow(backoffFactor, Math.max(0, attempts - 1))
+    );
+    return exp;
+  }
+
+  async function runOnce() {
+    timer = null;
+    if (stopped) return;
+    attempts += 1;
+    let observed;
+    try {
+      observed = await fetchActualChain();
+    } catch (err) {
+      status = 'rpc_down';
+      reason = 'pali_path_rpc_down';
+      log('warn', 'paliChainGuard.rpc_error', {
+        attempts,
+        err: err && err.message,
+      });
+      schedule(nextRetryDelay());
+      return;
+    }
+    const norm = normalizeChainString(observed);
+    if (!norm) {
+      status = 'rpc_down';
+      reason = 'pali_path_rpc_down';
+      log('warn', 'paliChainGuard.unparseable_chain', {
+        attempts,
+        observed,
+      });
+      schedule(nextRetryDelay());
+      return;
+    }
+    actualChain = norm;
+    if (norm === declared) {
+      status = 'verified';
+      reason = null;
+      log('info', 'paliChainGuard.verified', {
+        attempts,
+        declared,
+        actual: norm,
+      });
+      // Terminal success: no more timers.
+      return;
+    }
+    status = 'mismatch';
+    reason = 'pali_path_chain_mismatch';
+    // Terminal failure — log LOUDLY so the operator notices. The
+    // only correct recovery is to fix the env and restart.
+    log('error', 'paliChainGuard.mismatch', {
+      attempts,
+      declaredChain: declared,
+      actualChain: norm,
+      hint:
+        'SYSCOIN_NETWORK does not match the chain behind SYSCOIN_RPC_*;' +
+        ' Pali collateral path has been DISABLED for this process.' +
+        ' Fix the env and restart to re-enable it.',
+    });
+  }
+
+  function start() {
+    if (!declared) {
+      // Nothing to verify — stay in the unconfigured state.
+      return;
+    }
+    if (status === 'verified' || status === 'mismatch') {
+      // Terminal states; don't re-arm.
+      return;
+    }
+    schedule(initialDelayMs);
+  }
+
+  function stop() {
+    stopped = true;
+    clearTimer();
+  }
+
+  return {
+    start,
+    stop,
+    isReady() {
+      return status === 'verified';
+    },
+    // Non-null string when not ready; null when ready or
+    // indeterminate at construction time with no declared chain.
+    reason() {
+      return reason;
+    },
+    // Exposed for /network reporting + tests.
+    snapshot() {
+      return {
+        status,
+        reason,
+        declaredChain: declared,
+        actualChain,
+        attempts,
+      };
+    },
+  };
+}
+
+module.exports = {
+  createPaliChainGuard,
+  _internal: { normalizeChainString },
+};

--- a/lib/paliChainGuard.test.js
+++ b/lib/paliChainGuard.test.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const { createPaliChainGuard, _internal } = require('./paliChainGuard');
+
+// Scheduler fake: captures delays, gives the test code manual
+// control of when a scheduled callback fires. We avoid Jest's fake
+// timers because the guard's async probe interleaves with timer
+// callbacks, and flushing microtasks between setTimeout callbacks
+// with jest.runAllTimersAsync() adds noise that makes the sequence
+// harder to read.
+function makeScheduler() {
+  let nextId = 1;
+  const pending = new Map(); // id -> { fn, delay }
+  return {
+    setTimeout(fn, delay) {
+      const id = nextId++;
+      pending.set(id, { fn, delay });
+      return id;
+    },
+    clearTimeout(id) {
+      pending.delete(id);
+    },
+    // Test helpers.
+    _pending: () => pending,
+    _flush: async () => {
+      // Run at most one timer per iteration, re-reading pending
+      // after the callback since runOnce may re-schedule.
+      while (pending.size) {
+        const [id] = pending.keys();
+        const { fn } = pending.get(id);
+        pending.delete(id);
+        await fn();
+      }
+    },
+    _flushOne: async () => {
+      if (!pending.size) return;
+      const [id] = pending.keys();
+      const { fn } = pending.get(id);
+      pending.delete(id);
+      await fn();
+    },
+  };
+}
+
+describe('normalizeChainString', () => {
+  const { normalizeChainString } = _internal;
+  test('accepts canonical core chains', () => {
+    expect(normalizeChainString('main')).toBe('main');
+    expect(normalizeChainString('test')).toBe('test');
+    expect(normalizeChainString('regtest')).toBe('regtest');
+    expect(normalizeChainString('signet')).toBe('signet');
+  });
+  test('trims + lowercases', () => {
+    expect(normalizeChainString('  MAIN ')).toBe('main');
+  });
+  test('rejects everything else', () => {
+    expect(normalizeChainString('mainnet')).toBe(null);
+    expect(normalizeChainString(null)).toBe(null);
+    expect(normalizeChainString(undefined)).toBe(null);
+    expect(normalizeChainString(42)).toBe(null);
+  });
+});
+
+describe('createPaliChainGuard', () => {
+  test('throws when fetchActualChain is missing', () => {
+    expect(() => createPaliChainGuard({ declaredChain: 'main' })).toThrow(
+      /fetchActualChain/
+    );
+  });
+
+  test('constructs as unverified/unready with no schedule until start()', () => {
+    const scheduler = makeScheduler();
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain: jest.fn(),
+      scheduler,
+    });
+    expect(guard.isReady()).toBe(false);
+    expect(guard.reason()).toBe(null);
+    expect(guard.snapshot().status).toBe('unverified');
+    expect(scheduler._pending().size).toBe(0);
+  });
+
+  test('verifies when declared === observed (terminal success, no retries)', async () => {
+    const scheduler = makeScheduler();
+    const fetchActualChain = jest.fn().mockResolvedValue('main');
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain,
+      scheduler,
+      initialDelayMs: 1,
+    });
+    guard.start();
+    expect(scheduler._pending().size).toBe(1);
+    await scheduler._flushOne();
+    expect(guard.isReady()).toBe(true);
+    expect(guard.reason()).toBe(null);
+    expect(guard.snapshot()).toMatchObject({
+      status: 'verified',
+      actualChain: 'main',
+      attempts: 1,
+    });
+    // No re-arm after success.
+    expect(scheduler._pending().size).toBe(0);
+  });
+
+  test('mismatch is terminal and logs ERROR (no further probes)', async () => {
+    const scheduler = makeScheduler();
+    const log = jest.fn();
+    const fetchActualChain = jest.fn().mockResolvedValue('test');
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain,
+      scheduler,
+      log,
+      initialDelayMs: 1,
+    });
+    guard.start();
+    await scheduler._flushOne();
+    expect(guard.isReady()).toBe(false);
+    expect(guard.reason()).toBe('pali_path_chain_mismatch');
+    expect(guard.snapshot()).toMatchObject({
+      status: 'mismatch',
+      actualChain: 'test',
+    });
+    expect(scheduler._pending().size).toBe(0);
+    expect(fetchActualChain).toHaveBeenCalledTimes(1);
+    const errorLogs = log.mock.calls.filter((c) => c[0] === 'error');
+    expect(errorLogs).toHaveLength(1);
+    expect(errorLogs[0][1]).toBe('paliChainGuard.mismatch');
+  });
+
+  test('rpc_down is transient: retries with exponential backoff, eventually verifies', async () => {
+    const scheduler = makeScheduler();
+    let calls = 0;
+    const fetchActualChain = jest.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('ECONNREFUSED');
+      return 'main';
+    });
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain,
+      scheduler,
+      initialDelayMs: 100,
+      retryMinMs: 10,
+      retryMaxMs: 10000,
+      backoffFactor: 2,
+    });
+    guard.start();
+    const [first] = scheduler._pending().values();
+    expect(first.delay).toBe(100);
+
+    await scheduler._flushOne();
+    expect(guard.reason()).toBe('pali_path_rpc_down');
+    // After first failure: retryMin * 2^0 = 10
+    expect([...scheduler._pending().values()][0].delay).toBe(10);
+
+    await scheduler._flushOne();
+    // After second failure: retryMin * 2^1 = 20
+    expect([...scheduler._pending().values()][0].delay).toBe(20);
+
+    await scheduler._flushOne();
+    // Third call succeeds.
+    expect(guard.isReady()).toBe(true);
+    expect(fetchActualChain).toHaveBeenCalledTimes(3);
+    expect(scheduler._pending().size).toBe(0);
+  });
+
+  test('retry delay is clamped to retryMaxMs', async () => {
+    const scheduler = makeScheduler();
+    const fetchActualChain = jest.fn().mockRejectedValue(new Error('down'));
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain,
+      scheduler,
+      initialDelayMs: 1,
+      retryMinMs: 100,
+      retryMaxMs: 250,
+      backoffFactor: 10,
+    });
+    guard.start();
+    await scheduler._flushOne(); // attempt 1; next delay = 100
+    expect([...scheduler._pending().values()][0].delay).toBe(100);
+    await scheduler._flushOne(); // attempt 2; next delay = min(250, 1000) = 250
+    expect([...scheduler._pending().values()][0].delay).toBe(250);
+    await scheduler._flushOne(); // attempt 3; next delay = min(250, 10000) = 250
+    expect([...scheduler._pending().values()][0].delay).toBe(250);
+    guard.stop();
+  });
+
+  test('stop() cancels the pending timer and halts further probes', async () => {
+    const scheduler = makeScheduler();
+    const fetchActualChain = jest.fn().mockRejectedValue(new Error('down'));
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain,
+      scheduler,
+      initialDelayMs: 10,
+      retryMinMs: 10,
+    });
+    guard.start();
+    guard.stop();
+    expect(scheduler._pending().size).toBe(0);
+    // Even if something tries to re-run, the stopped flag guards.
+    await scheduler._flush();
+    expect(fetchActualChain).not.toHaveBeenCalled();
+  });
+
+  test('declaredChain missing or malformed => permanent unconfigured state', async () => {
+    const scheduler = makeScheduler();
+    const fetchActualChain = jest.fn();
+    const guard = createPaliChainGuard({
+      declaredChain: null,
+      fetchActualChain,
+      scheduler,
+    });
+    guard.start();
+    expect(scheduler._pending().size).toBe(0);
+    expect(guard.isReady()).toBe(false);
+    expect(guard.reason()).toBe('pali_not_configured');
+    expect(fetchActualChain).not.toHaveBeenCalled();
+  });
+
+  test('unparseable chain response is treated as rpc_down (transient)', async () => {
+    const scheduler = makeScheduler();
+    const fetchActualChain = jest
+      .fn()
+      .mockResolvedValueOnce('') // bogus
+      .mockResolvedValueOnce('main');
+    const guard = createPaliChainGuard({
+      declaredChain: 'main',
+      fetchActualChain,
+      scheduler,
+      initialDelayMs: 1,
+      retryMinMs: 1,
+    });
+    guard.start();
+    await scheduler._flushOne();
+    expect(guard.reason()).toBe('pali_path_rpc_down');
+    await scheduler._flushOne();
+    expect(guard.isReady()).toBe(true);
+  });
+});

--- a/lib/proposalPsbt.js
+++ b/lib/proposalPsbt.js
@@ -1,0 +1,367 @@
+'use strict';
+
+// Governance-collateral PSBT builder. This module is the server side of
+// the "Pay with Pali" path: the frontend hands us the connected wallet's
+// xpub + change address, we ask syscoinjs-lib to pick UTXOs off Blockbook
+// and compose a transaction with a single OP_RETURN output committing to
+// the proposal hash for 150 SYS, and we return the unsigned PSBT in the
+// JSON envelope that Pali's `sys_signAndSend` expects.
+//
+// Everything this module knows about Syscoin's governance collateral
+// rule traces back to one function in Core —
+// CGovernanceObject::IsCollateralValid
+// (src/governance/governanceobject.cpp). The relevant slice:
+//
+//     CScript findScript;
+//     findScript << OP_RETURN << ToByteVector(nExpectedHash);
+//     ...
+//     if (output.scriptPubKey.IsUnspendable()
+//         && output.scriptPubKey == findScript
+//         && output.nValue >= nMinFee) {
+//       foundOpReturn = true;
+//     }
+//
+// Three things worth underlining from that:
+//
+//   1. The OP_RETURN output itself must carry >= 150 SYS. The 150 SYS is
+//      "burned" simply by virtue of OP_RETURN being unspendable — there
+//      is no separate burn-address step and no second output.
+//   2. The script must be EXACTLY `OP_RETURN <push 32 bytes of hash>`.
+//      That's `0x6a 0x20 <32 bytes>`. Any other push op (e.g. an
+//      OP_PUSHDATA1 wrapper the encoder might emit for marginal sizes)
+//      would make `scriptPubKey == findScript` false and Core would
+//      reject the collateral.
+//   3. The expected hash is the 32 raw bytes of `GetHash()` in internal
+//      byte order. We already have that buffer from proposalHash.js's
+//      `opReturnBytes` field; the route passes the hex form through.
+//
+// syscoinjs-lib's path to compose this (via SyscoinJSLib.createTransaction)
+// does the right thing for us so long as we pass a script-only output
+// (no address) with a BN value — its internal coin-selector
+// (`coinselectsyscoin/utils.js`) sizes OP_RETURN outputs with
+// `output.script.length + 5 + 8` and includes them verbatim in the
+// output set. The `createPSBTFromRes` finalizer then adds the script as
+// an `addOutput({ script, address: null, value })`, which is a standard
+// bitcoinjs Psbt output and produces exactly the 0x6a 0x20 <hash>
+// scriptPubKey Core looks for.
+
+const BN = require('bn.js');
+
+// 150 SYS — identical constant to the one in routes/govProposals.js.
+// Duplicated here rather than imported to keep this module standalone
+// (it is used from both a route handler and a dispatcher test harness).
+const COLLATERAL_FEE_SATS_BN = new BN('15000000000');
+
+// Default fee rate (sat/vByte). Matches syscoinjs-lib's own default,
+// but named here so callers can see what they're getting without
+// reading the library.
+const DEFAULT_FEE_RATE = 10;
+
+// Generous sanity bounds. A rate of 0 would fail at the `coinSelect`
+// step but with a less helpful error; a rate above this is almost
+// certainly a typo (500 sat/vB would pay >$150 for a 300-byte tx at
+// $0.001/sat).
+const MIN_FEE_RATE = 1;
+const MAX_FEE_RATE = 1000;
+
+// Syscoin zpub / vpub prefixes. These are the ONLY two forms Pali
+// currently emits for a connected UTXO account; anything else is
+// either a Bitcoin xpub/ypub or an EVM artifact and would build a
+// PSBT on the wrong network.
+const MAINNET_XPUB_PREFIX = 'zpub';
+const TESTNET_XPUB_PREFIX = 'vpub';
+
+// Script helper: compose `OP_RETURN <push-32-bytes>` with a literal
+// OP_PUSHBYTES_32 opcode so there's no ambiguity about which push op
+// bitcoinjs would pick. Core compares the serialized script byte-for
+// -byte, so we build the bytes ourselves rather than call
+// `bitcoinjs.payments.embed` (which uses the minimal push encoding —
+// for 32 bytes that's 0x20, but we leave nothing to chance).
+function buildOpReturnScript(opReturnHex) {
+  if (typeof opReturnHex !== 'string' || !/^[0-9a-f]{64}$/.test(opReturnHex)) {
+    const e = new Error('bad_op_return');
+    e.code = 'bad_op_return';
+    throw e;
+  }
+  const OP_RETURN = 0x6a;
+  const PUSH_32 = 0x20;
+  return Buffer.concat([
+    Buffer.from([OP_RETURN, PUSH_32]),
+    Buffer.from(opReturnHex, 'hex'),
+  ]);
+}
+
+// Validate xpub shape + network affinity. We don't try to decode the
+// base58 body — that's the signer's job; we just refuse obviously
+// wrong inputs so a typo doesn't turn into a 500 from deep inside
+// syscoinjs-lib.
+//
+// `networkKey` is 'mainnet' or 'testnet' (as set by the caller from
+// Core's getblockchaininfo).
+function assertXpubMatchesNetwork(xpub, networkKey) {
+  if (typeof xpub !== 'string' || xpub.length < 20 || xpub.length > 120) {
+    const e = new Error('bad_xpub');
+    e.code = 'bad_xpub';
+    throw e;
+  }
+  if (networkKey === 'mainnet' && !xpub.startsWith(MAINNET_XPUB_PREFIX)) {
+    const e = new Error('network_mismatch');
+    e.code = 'network_mismatch';
+    e.detail = `expected ${MAINNET_XPUB_PREFIX}... for mainnet`;
+    throw e;
+  }
+  if (networkKey === 'testnet' && !xpub.startsWith(TESTNET_XPUB_PREFIX)) {
+    const e = new Error('network_mismatch');
+    e.code = 'network_mismatch';
+    e.detail = `expected ${TESTNET_XPUB_PREFIX}... for testnet`;
+    throw e;
+  }
+}
+
+// Validate the change address by asking bitcoinjs to turn it into an
+// output script on the selected network. Wrong-network addresses
+// throw with the bitcoinjs-specific message, which we translate to a
+// clear `bad_change_address` or `network_mismatch`.
+function assertChangeAddress(bitcoinjs, address, network, networkKey) {
+  if (typeof address !== 'string' || address.length < 10 || address.length > 100) {
+    const e = new Error('bad_change_address');
+    e.code = 'bad_change_address';
+    throw e;
+  }
+  try {
+    bitcoinjs.address.toOutputScript(address, network);
+  } catch (err) {
+    // bitcoinjs says things like "Invalid checksum" or "has no matching
+    // Script". "has no matching" strongly implies a cross-network
+    // address (e.g. sys1... on a testnet build). We separate the two
+    // because one is the user's fault and the other is the wrong-
+    // wallet-network case that needs a different UI hint.
+    const msg = String(err && err.message ? err.message : '');
+    if (/has no matching/i.test(msg) || /Invalid version/i.test(msg)) {
+      const e = new Error('network_mismatch');
+      e.code = 'network_mismatch';
+      e.detail = `change address is not valid on ${networkKey}`;
+      throw e;
+    }
+    const e = new Error('bad_change_address');
+    e.code = 'bad_change_address';
+    e.detail = msg || 'invalid address';
+    throw e;
+  }
+}
+
+// Fee rate validation. syscoinjs-lib accepts both plain numbers and
+// BN for the feeRate arg; we normalize to a BN to avoid floating-
+// point surprises in the coin-selector.
+function normalizeFeeRate(feeRate) {
+  if (feeRate === undefined || feeRate === null || feeRate === '') {
+    return new BN(DEFAULT_FEE_RATE);
+  }
+  const n = Number(feeRate);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < MIN_FEE_RATE || n > MAX_FEE_RATE) {
+    const e = new Error('bad_fee_rate');
+    e.code = 'bad_fee_rate';
+    throw e;
+  }
+  return new BN(n);
+}
+
+// Map a syscoinjs-lib error back to our typed-code vocabulary.
+// createTransaction throws with `code: 402` for any coinselect
+// failure (insufficient funds, unreachable Blockbook, empty UTXO
+// set, etc.). We pull the original message + any shortfall the
+// library computed so the UI can render "need X more SYS".
+function translateSyscoinError(err) {
+  if (!err || typeof err !== 'object') {
+    const e = new Error('pali_psbt_build_failed');
+    e.code = 'pali_psbt_build_failed';
+    e.cause = err;
+    return e;
+  }
+  const msg = typeof err.message === 'string' ? err.message : '';
+
+  // Network-layer: axios surfaces a `.code` string on connection
+  // failures ('ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT', ...). These
+  // come *out* of syscoinjs-lib unwrapped because its fetch helper
+  // just rethrows.
+  const transient = ['ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT', 'EAI_AGAIN', 'ECONNRESET'];
+  if (typeof err.code === 'string' && transient.includes(err.code)) {
+    const e = new Error('blockbook_unreachable');
+    e.code = 'blockbook_unreachable';
+    e.detail = err.code;
+    e.cause = err;
+    return e;
+  }
+  // axios HTTP-level: 5xx from Blockbook itself.
+  if (err.response && err.response.status && err.response.status >= 500) {
+    const e = new Error('blockbook_unreachable');
+    e.code = 'blockbook_unreachable';
+    e.detail = `upstream_${err.response.status}`;
+    e.cause = err;
+    return e;
+  }
+
+  // syscoinjs-lib's coinselect wrapping: the library sets
+  // `err.code === 402` and attaches `.shortfall` / `.outputTotal`
+  // on insufficient funds.
+  if (err.code === 402 || /insufficient/i.test(msg)) {
+    const e = new Error('insufficient_funds');
+    e.code = 'insufficient_funds';
+    if (err.shortfall) {
+      try {
+        e.shortfallSats = err.shortfall.toString();
+      } catch (_e) {
+        /* BN with a weird backing; ignore */
+      }
+    }
+    e.cause = err;
+    return e;
+  }
+
+  const e = new Error(msg || 'pali_psbt_build_failed');
+  e.code = 'pali_psbt_build_failed';
+  e.cause = err;
+  return e;
+}
+
+// Build an unsigned collateral PSBT.
+//
+// Parameters:
+//   - opReturnHex    : 64-char lowercase hex, 32-byte OP_RETURN payload
+//                      (this is the 32-byte internal-order proposal hash,
+//                      i.e. what proposalHash.js returns as `opReturnBytes`)
+//   - xpub           : connected Pali account's zpub/vpub
+//   - changeAddress  : connected Pali account's next change address
+//                      (sys_getChangeAddress result)
+//   - feeRate        : optional sat/vByte integer, defaults to 10
+//   - syscoinClient  : { network, networkKey, createTransaction(txOpts, change, outs, feeRate, xpub) }
+//                      — abstraction so tests stub without standing up
+//                      a real Blockbook. In production, factoryForEnv()
+//                      builds one around a SyscoinJSLib instance.
+//
+// Returns: { psbt: { psbt: <base64>, assets: <stringified-map> },
+//            feeSats: "<integer>" }
+//
+// Throws: Error with `.code` from the taxonomy above. All other errors
+// are re-thrown after wrapping in a generic `pali_psbt_build_failed`,
+// never as a raw library error — callers can rely on the code set.
+async function buildCollateralPsbt({
+  opReturnHex,
+  xpub,
+  changeAddress,
+  feeRate,
+  syscoinClient,
+} = {}) {
+  if (!syscoinClient || typeof syscoinClient.createTransaction !== 'function') {
+    throw new Error('buildCollateralPsbt: syscoinClient is required');
+  }
+  const { network, networkKey, bitcoinjs, exportPsbtToJson } = syscoinClient;
+  if (!network || !networkKey || !bitcoinjs || typeof exportPsbtToJson !== 'function') {
+    throw new Error('buildCollateralPsbt: syscoinClient is malformed');
+  }
+
+  assertXpubMatchesNetwork(xpub, networkKey);
+  assertChangeAddress(bitcoinjs, changeAddress, network, networkKey);
+  const feeRateBN = normalizeFeeRate(feeRate);
+
+  const script = buildOpReturnScript(opReturnHex);
+  const outputs = [
+    {
+      // Intentionally no `address` field so syscointx-js's
+      // "if (!output.address) output.address = changeAddress" branch
+      // DOES fire — Pali's request-pipeline uses that proprietary
+      // address metadata to route the signing popup to the account
+      // that owns the change address (which is the same account that
+      // owns the inputs we're selecting). Leaving it unset would
+      // work, but having the library fill it in with our change
+      // address is the cleanest signal for Pali's routing.
+      script,
+      value: COLLATERAL_FEE_SATS_BN,
+    },
+  ];
+
+  let result;
+  try {
+    // rbf:false matches Core's `gobject prepare` wallet RPC, which
+    // produces non-RBF collateral txs. We explicitly opt-out of the
+    // syscoinjs-lib default (`rbf: true`) so the dispatcher's 6-conf
+    // wait doesn't race with an RBF bump by the user. If a user
+    // really needs to bump, they create a new proposal — the
+    // original 150 SYS is a sunk cost regardless.
+    result = await syscoinClient.createTransaction(
+      { rbf: false },
+      changeAddress,
+      outputs,
+      feeRateBN,
+      xpub
+    );
+  } catch (err) {
+    throw translateSyscoinError(err);
+  }
+
+  if (!result || !result.psbt) {
+    const e = new Error('pali_psbt_build_failed');
+    e.code = 'pali_psbt_build_failed';
+    throw e;
+  }
+
+  // syscoinjs-lib's `exportPsbtToJson` emits exactly the shape Pali's
+  // `PsbtUtils.fromPali` expects: { psbt: <base64>, assets: <JSON> }.
+  // We pass no assetsMap because native-coin sends don't have one.
+  const envelope = exportPsbtToJson(result.psbt, undefined);
+
+  // Fee is reported as a number of sats from syscoinjs-lib
+  // (`res.fee`). We stringify to keep JSON-number precision honest
+  // even though 10 sat/vB * ~200 vB fits comfortably in a Number.
+  const feeSatsStr = String(result.fee != null ? result.fee : 0);
+
+  return { psbt: envelope, feeSats: feeSatsStr };
+}
+
+// Factory for the production syscoinClient wrapper. Reads
+// `SYSCOIN_BLOCKBOOK_URL` from the env and instantiates a
+// `SyscoinJSLib` bound to a given network. Returns `null` when the
+// env var is missing — the caller (appFactory.js) then omits the
+// /collateral/psbt route, so the FE feature-detects the absence and
+// keeps the manual fallback visible.
+//
+// `networkKey`: 'mainnet' | 'testnet' — picked by the caller from
+// Core's getblockchaininfo.chain ('main' -> mainnet, anything else
+// -> testnet).
+function createDefaultSyscoinClient({ blockbookURL, networkKey } = {}) {
+  if (!blockbookURL || typeof blockbookURL !== 'string') return null;
+  if (networkKey !== 'mainnet' && networkKey !== 'testnet') {
+    throw new Error(`createDefaultSyscoinClient: bad networkKey ${networkKey}`);
+  }
+  // Lazy require: tests that stub the client never pull syscoinjs-lib
+  // into the require graph, which keeps unit-test startup fast.
+  // eslint-disable-next-line global-require
+  const syscoinjs = require('syscoinjs-lib');
+  const network = syscoinjs.utils.syscoinNetworks[networkKey];
+  const lib = new syscoinjs.SyscoinJSLib(null, blockbookURL, network);
+  return {
+    network,
+    networkKey,
+    bitcoinjs: syscoinjs.utils.bitcoinjs,
+    exportPsbtToJson: syscoinjs.utils.exportPsbtToJson,
+    createTransaction: (txOpts, changeAddress, outputs, feeRate, xpub) =>
+      lib.createTransaction(txOpts, changeAddress, outputs, feeRate, xpub),
+  };
+}
+
+module.exports = {
+  buildCollateralPsbt,
+  createDefaultSyscoinClient,
+  // Exposed for tests.
+  _internal: {
+    buildOpReturnScript,
+    assertXpubMatchesNetwork,
+    assertChangeAddress,
+    normalizeFeeRate,
+    translateSyscoinError,
+    COLLATERAL_FEE_SATS_BN,
+    DEFAULT_FEE_RATE,
+    MIN_FEE_RATE,
+    MAX_FEE_RATE,
+  },
+};

--- a/lib/proposalPsbt.js
+++ b/lib/proposalPsbt.js
@@ -107,12 +107,14 @@ function assertXpubMatchesNetwork(xpub, networkKey) {
   if (networkKey === 'mainnet' && !xpub.startsWith(MAINNET_XPUB_PREFIX)) {
     const e = new Error('network_mismatch');
     e.code = 'network_mismatch';
+    e.field = 'xpub';
     e.detail = `expected ${MAINNET_XPUB_PREFIX}... for mainnet`;
     throw e;
   }
   if (networkKey === 'testnet' && !xpub.startsWith(TESTNET_XPUB_PREFIX)) {
     const e = new Error('network_mismatch');
     e.code = 'network_mismatch';
+    e.field = 'xpub';
     e.detail = `expected ${TESTNET_XPUB_PREFIX}... for testnet`;
     throw e;
   }
@@ -140,6 +142,7 @@ function assertChangeAddress(bitcoinjs, address, network, networkKey) {
     if (/has no matching/i.test(msg) || /Invalid version/i.test(msg)) {
       const e = new Error('network_mismatch');
       e.code = 'network_mismatch';
+      e.field = 'changeAddress';
       e.detail = `change address is not valid on ${networkKey}`;
       throw e;
     }
@@ -171,6 +174,34 @@ function normalizeFeeRate(feeRate) {
 // failure (insufficient funds, unreachable Blockbook, empty UTXO
 // set, etc.). We pull the original message + any shortfall the
 // library computed so the UI can render "need X more SYS".
+// Walk `err.cause` chains (up to a small depth to avoid adversarial
+// cycles) looking for a transport-layer errno string. Node 18+'s
+// undici `fetch` throws `TypeError('fetch failed')` with the real
+// errno nested under `.cause.code`, so a top-level-only check would
+// misclassify those as generic build failures and 500 the client.
+function findTransientCode(err) {
+  const transient = new Set([
+    'ENOTFOUND',
+    'ECONNREFUSED',
+    'ETIMEDOUT',
+    'EAI_AGAIN',
+    'ECONNRESET',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+    'UND_ERR_HEADERS_TIMEOUT',
+  ]);
+  const seen = new Set();
+  let cur = err;
+  for (let i = 0; i < 5 && cur && typeof cur === 'object' && !seen.has(cur); i++) {
+    seen.add(cur);
+    if (typeof cur.code === 'string' && transient.has(cur.code)) {
+      return cur.code;
+    }
+    cur = cur.cause;
+  }
+  return null;
+}
+
 function translateSyscoinError(err) {
   if (!err || typeof err !== 'object') {
     const e = new Error('pali_psbt_build_failed');
@@ -181,14 +212,25 @@ function translateSyscoinError(err) {
   const msg = typeof err.message === 'string' ? err.message : '';
 
   // Network-layer: axios surfaces a `.code` string on connection
-  // failures ('ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT', ...). These
-  // come *out* of syscoinjs-lib unwrapped because its fetch helper
-  // just rethrows.
-  const transient = ['ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT', 'EAI_AGAIN', 'ECONNRESET'];
-  if (typeof err.code === 'string' && transient.includes(err.code)) {
+  // failures ('ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT', ...). In
+  // Node 18+ environments using undici/fetch, the errno is nested
+  // under `.cause.code` with a top-level `TypeError: fetch failed`;
+  // walk the cause chain so both reach this branch.
+  const transientCode = findTransientCode(err);
+  if (transientCode) {
     const e = new Error('blockbook_unreachable');
     e.code = 'blockbook_unreachable';
-    e.detail = err.code;
+    e.detail = transientCode;
+    e.cause = err;
+    return e;
+  }
+  // fetch 'TypeError: fetch failed' with no identifiable errno in
+  // the cause chain — still a transport failure from our
+  // perspective, just one we can't attribute more precisely.
+  if (err instanceof TypeError && /fetch failed/i.test(msg)) {
+    const e = new Error('blockbook_unreachable');
+    e.code = 'blockbook_unreachable';
+    e.detail = 'fetch_failed';
     e.cause = err;
     return e;
   }

--- a/lib/proposalPsbt.test.js
+++ b/lib/proposalPsbt.test.js
@@ -1,0 +1,432 @@
+'use strict';
+
+// Unit tests for lib/proposalPsbt.js.
+//
+// We stub `syscoinClient.createTransaction` so these tests run in
+// isolation from syscoinjs-lib / Blockbook — the goal is to pin down:
+//   1. Input validation behaves exactly as documented in the module.
+//   2. The OP_RETURN script we hand into createTransaction is byte-
+//      for-byte what Syscoin Core's IsCollateralValid expects.
+//   3. The 150-SYS value is a BN (coinselect needs `BN.isBN(v)`), and
+//      the collateral output carries that value unchanged.
+//   4. Error translation covers the actual shapes syscoinjs-lib /
+//      axios emit on the unhappy paths we care about.
+
+const BN = require('bn.js');
+const {
+  buildCollateralPsbt,
+  _internal: {
+    buildOpReturnScript,
+    assertXpubMatchesNetwork,
+    assertChangeAddress,
+    normalizeFeeRate,
+    translateSyscoinError,
+    COLLATERAL_FEE_SATS_BN,
+    DEFAULT_FEE_RATE,
+    MIN_FEE_RATE,
+    MAX_FEE_RATE,
+  },
+} = require('./proposalPsbt');
+
+// A 64-hex dummy proposal hash — exercises the full 32-byte push path.
+const SAMPLE_OP_RETURN_HEX =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+// A zpub that starts with the mainnet prefix. The content after the
+// prefix is irrelevant to our validator (we don't decode base58);
+// we just need the right prefix bytes for the regex we apply.
+const SAMPLE_MAINNET_XPUB =
+  'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs';
+const SAMPLE_TESTNET_XPUB =
+  'vpub5SLqN2bLY4WeahzxN4sfhUDZBJKPPcx7YbG98hDrcppJ3NKmPWDMmtFKccJ4yMkspGFcN5hnDVfA2dcrNzscCLkRf4JtyyGkVqeDfo8nAJ4';
+
+// Real sys1 bech32 address (from the existing route tests) — decoded
+// by bitcoinjs on the mainnet network.
+const SAMPLE_MAINNET_ADDRESS = 'sys1qw508d6qejxtdg4y5r3zarvary0c5xw7kygmkq9';
+// Corresponding tsys1 bech32 on testnet.
+const SAMPLE_TESTNET_ADDRESS = 'tsys1qw508d6qejxtdg4y5r3zarvary0c5xw7kxn5q3y';
+
+// A stub bitcoinjs.address that handles the bech32 HRP check without
+// pulling in real bitcoinjs-lib for every test. Returns a Buffer when
+// the address matches the expected HRP for the network, throws with
+// the "has no matching Script" shape bitcoinjs uses otherwise.
+function makeFakeBitcoinjs(expectedHrp) {
+  return {
+    address: {
+      toOutputScript(addr, _network) {
+        if (typeof addr !== 'string' || addr.length < 10) {
+          const e = new Error('Invalid checksum');
+          throw e;
+        }
+        if (!addr.toLowerCase().startsWith(expectedHrp)) {
+          const e = new Error(
+            `${addr} has no matching Script on the configured network`
+          );
+          throw e;
+        }
+        return Buffer.from('76a914' + '00'.repeat(20) + '88ac', 'hex');
+      },
+    },
+  };
+}
+
+function makeSyscoinClientStub({
+  networkKey = 'mainnet',
+  expectedHrp = 'sys1',
+  createTransaction,
+  exportPsbtToJson,
+} = {}) {
+  return {
+    network: { /* opaque network object */ },
+    networkKey,
+    bitcoinjs: makeFakeBitcoinjs(expectedHrp),
+    exportPsbtToJson:
+      exportPsbtToJson ||
+      (() => ({ psbt: 'BASE64PSBT==', assets: '[]' })),
+    createTransaction:
+      createTransaction ||
+      (async () => ({
+        psbt: { fakePsbtMarker: true },
+        fee: 2000,
+      })),
+  };
+}
+
+describe('buildOpReturnScript', () => {
+  test('emits 0x6a 0x20 <32 bytes> for a 64-hex input', () => {
+    const out = buildOpReturnScript(SAMPLE_OP_RETURN_HEX);
+    expect(out.length).toBe(34);
+    expect(out[0]).toBe(0x6a); // OP_RETURN
+    expect(out[1]).toBe(0x20); // push 32 bytes
+    expect(out.slice(2).toString('hex')).toBe(SAMPLE_OP_RETURN_HEX);
+  });
+
+  test('rejects non-hex / wrong-length payloads', () => {
+    for (const bad of [
+      '',
+      'abc',
+      'zz'.repeat(32),
+      SAMPLE_OP_RETURN_HEX.toUpperCase(), // our regex is lowercase-only
+      SAMPLE_OP_RETURN_HEX + '00', // 66 chars
+      null,
+      undefined,
+      42,
+    ]) {
+      let thrown;
+      try {
+        buildOpReturnScript(bad);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeDefined();
+      expect(thrown.code).toBe('bad_op_return');
+    }
+  });
+});
+
+describe('assertXpubMatchesNetwork', () => {
+  test('accepts zpub for mainnet, vpub for testnet', () => {
+    expect(() =>
+      assertXpubMatchesNetwork(SAMPLE_MAINNET_XPUB, 'mainnet')
+    ).not.toThrow();
+    expect(() =>
+      assertXpubMatchesNetwork(SAMPLE_TESTNET_XPUB, 'testnet')
+    ).not.toThrow();
+  });
+
+  test('rejects cross-network xpub with network_mismatch', () => {
+    expect.assertions(2);
+    try {
+      assertXpubMatchesNetwork(SAMPLE_MAINNET_XPUB, 'testnet');
+    } catch (err) {
+      expect(err.code).toBe('network_mismatch');
+    }
+    try {
+      assertXpubMatchesNetwork(SAMPLE_TESTNET_XPUB, 'mainnet');
+    } catch (err) {
+      expect(err.code).toBe('network_mismatch');
+    }
+  });
+
+  test('rejects wrong-shape inputs with bad_xpub', () => {
+    for (const bad of ['', 'xpub', null, undefined, 'x'.repeat(200), 42]) {
+      let thrown;
+      try {
+        assertXpubMatchesNetwork(bad, 'mainnet');
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeDefined();
+      expect(thrown.code).toBe('bad_xpub');
+    }
+  });
+});
+
+describe('assertChangeAddress', () => {
+  test('passes for a matching-network bech32 address', () => {
+    expect(() =>
+      assertChangeAddress(
+        makeFakeBitcoinjs('sys1'),
+        SAMPLE_MAINNET_ADDRESS,
+        { /* fake network */ },
+        'mainnet'
+      )
+    ).not.toThrow();
+  });
+
+  test('maps cross-network bitcoinjs error to network_mismatch', () => {
+    try {
+      assertChangeAddress(
+        makeFakeBitcoinjs('sys1'),
+        SAMPLE_TESTNET_ADDRESS,
+        {},
+        'mainnet'
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err.code).toBe('network_mismatch');
+    }
+  });
+
+  test('maps other bitcoinjs errors to bad_change_address', () => {
+    try {
+      assertChangeAddress(
+        {
+          address: {
+            toOutputScript() {
+              throw new Error('Invalid checksum');
+            },
+          },
+        },
+        'sys1junk',
+        {},
+        'mainnet'
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err.code).toBe('bad_change_address');
+    }
+  });
+});
+
+describe('normalizeFeeRate', () => {
+  test('defaults to DEFAULT_FEE_RATE', () => {
+    expect(normalizeFeeRate().toNumber()).toBe(DEFAULT_FEE_RATE);
+    expect(normalizeFeeRate(null).toNumber()).toBe(DEFAULT_FEE_RATE);
+    expect(normalizeFeeRate('').toNumber()).toBe(DEFAULT_FEE_RATE);
+  });
+
+  test('accepts integer inputs within [MIN,MAX]', () => {
+    expect(normalizeFeeRate(MIN_FEE_RATE).toNumber()).toBe(MIN_FEE_RATE);
+    expect(normalizeFeeRate(MAX_FEE_RATE).toNumber()).toBe(MAX_FEE_RATE);
+    expect(normalizeFeeRate('42').toNumber()).toBe(42);
+  });
+
+  test('rejects out-of-range / non-integer inputs', () => {
+    for (const bad of [
+      0,
+      -1,
+      MAX_FEE_RATE + 1,
+      1.5,
+      'foo',
+      NaN,
+      Infinity,
+    ]) {
+      let thrown;
+      try {
+        normalizeFeeRate(bad);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeDefined();
+      expect(thrown.code).toBe('bad_fee_rate');
+    }
+  });
+});
+
+describe('translateSyscoinError', () => {
+  test('insufficient_funds picks up shortfall from BN', () => {
+    const bn = new BN('12345');
+    const e = translateSyscoinError({
+      code: 402,
+      message: 'insufficient funds',
+      shortfall: bn,
+    });
+    expect(e.code).toBe('insufficient_funds');
+    expect(e.shortfallSats).toBe('12345');
+  });
+
+  test('blockbook transient codes map to blockbook_unreachable', () => {
+    for (const c of ['ENOTFOUND', 'ECONNREFUSED', 'ETIMEDOUT']) {
+      const e = translateSyscoinError({ code: c, message: 'boom' });
+      expect(e.code).toBe('blockbook_unreachable');
+      expect(e.detail).toBe(c);
+    }
+  });
+
+  test('blockbook 5xx HTTP error maps to blockbook_unreachable', () => {
+    const e = translateSyscoinError({
+      response: { status: 503 },
+      message: 'server down',
+    });
+    expect(e.code).toBe('blockbook_unreachable');
+    expect(e.detail).toBe('upstream_503');
+  });
+
+  test('unknown error shape -> pali_psbt_build_failed', () => {
+    const e = translateSyscoinError({ message: 'weird' });
+    expect(e.code).toBe('pali_psbt_build_failed');
+  });
+});
+
+describe('buildCollateralPsbt (integration via stub)', () => {
+  test('builds a 150-SYS OP_RETURN output byte-for-byte', async () => {
+    let captured;
+    const client = makeSyscoinClientStub({
+      createTransaction: async (txOpts, change, outs, feeRate, xpub) => {
+        captured = { txOpts, change, outs, feeRate, xpub };
+        return { psbt: { stub: true }, fee: 3210 };
+      },
+    });
+
+    const result = await buildCollateralPsbt({
+      opReturnHex: SAMPLE_OP_RETURN_HEX,
+      xpub: SAMPLE_MAINNET_XPUB,
+      changeAddress: SAMPLE_MAINNET_ADDRESS,
+      syscoinClient: client,
+    });
+
+    // ---- returned envelope ---------------------------------------
+    expect(result).toEqual({
+      psbt: { psbt: 'BASE64PSBT==', assets: '[]' },
+      feeSats: '3210',
+    });
+
+    // ---- createTransaction call shape ----------------------------
+    expect(captured.txOpts).toEqual({ rbf: false });
+    expect(captured.change).toBe(SAMPLE_MAINNET_ADDRESS);
+    expect(captured.xpub).toBe(SAMPLE_MAINNET_XPUB);
+    // Default fee rate = 10 (BN).
+    expect(BN.isBN(captured.feeRate)).toBe(true);
+    expect(captured.feeRate.toNumber()).toBe(DEFAULT_FEE_RATE);
+
+    // ---- outputs array: one script-only 150-SYS collateral -------
+    expect(captured.outs).toHaveLength(1);
+    const out = captured.outs[0];
+    expect(Object.prototype.hasOwnProperty.call(out, 'address')).toBe(false);
+    expect(Buffer.isBuffer(out.script)).toBe(true);
+    expect(out.script[0]).toBe(0x6a);
+    expect(out.script[1]).toBe(0x20);
+    expect(out.script.slice(2).toString('hex')).toBe(SAMPLE_OP_RETURN_HEX);
+    expect(BN.isBN(out.value)).toBe(true);
+    // Equal to 150 SYS in sats (150 * 1e8 = 15_000_000_000).
+    expect(out.value.eq(COLLATERAL_FEE_SATS_BN)).toBe(true);
+    expect(out.value.toString(10)).toBe('15000000000');
+  });
+
+  test('passes through caller feeRate when valid', async () => {
+    let capturedFeeRate;
+    const client = makeSyscoinClientStub({
+      createTransaction: async (_o, _c, _outs, feeRate) => {
+        capturedFeeRate = feeRate;
+        return { psbt: { stub: true }, fee: 0 };
+      },
+    });
+    await buildCollateralPsbt({
+      opReturnHex: SAMPLE_OP_RETURN_HEX,
+      xpub: SAMPLE_MAINNET_XPUB,
+      changeAddress: SAMPLE_MAINNET_ADDRESS,
+      feeRate: 42,
+      syscoinClient: client,
+    });
+    expect(capturedFeeRate.toNumber()).toBe(42);
+  });
+
+  test('translates syscoinjs insufficient_funds to typed error', async () => {
+    const client = makeSyscoinClientStub({
+      createTransaction: async () => {
+        const e = new Error('insufficient funds or invalid inputs');
+        e.code = 402;
+        e.shortfall = new BN('99999999');
+        throw e;
+      },
+    });
+    await expect(
+      buildCollateralPsbt({
+        opReturnHex: SAMPLE_OP_RETURN_HEX,
+        xpub: SAMPLE_MAINNET_XPUB,
+        changeAddress: SAMPLE_MAINNET_ADDRESS,
+        syscoinClient: client,
+      })
+    ).rejects.toMatchObject({
+      code: 'insufficient_funds',
+      shortfallSats: '99999999',
+    });
+  });
+
+  test('translates axios ENOTFOUND to blockbook_unreachable', async () => {
+    const client = makeSyscoinClientStub({
+      createTransaction: async () => {
+        const e = new Error('getaddrinfo ENOTFOUND');
+        e.code = 'ENOTFOUND';
+        throw e;
+      },
+    });
+    await expect(
+      buildCollateralPsbt({
+        opReturnHex: SAMPLE_OP_RETURN_HEX,
+        xpub: SAMPLE_MAINNET_XPUB,
+        changeAddress: SAMPLE_MAINNET_ADDRESS,
+        syscoinClient: client,
+      })
+    ).rejects.toMatchObject({
+      code: 'blockbook_unreachable',
+      detail: 'ENOTFOUND',
+    });
+  });
+
+  test('rejects cross-network xpub before any RPC', async () => {
+    let called = false;
+    const client = makeSyscoinClientStub({
+      networkKey: 'testnet',
+      expectedHrp: 'tsys1',
+      createTransaction: async () => {
+        called = true;
+        return { psbt: { stub: true }, fee: 0 };
+      },
+    });
+    await expect(
+      buildCollateralPsbt({
+        opReturnHex: SAMPLE_OP_RETURN_HEX,
+        xpub: SAMPLE_MAINNET_XPUB, // zpub on testnet client
+        changeAddress: SAMPLE_TESTNET_ADDRESS,
+        syscoinClient: client,
+      })
+    ).rejects.toMatchObject({ code: 'network_mismatch' });
+    expect(called).toBe(false);
+  });
+
+  test('rejects missing syscoinClient.createTransaction', async () => {
+    await expect(
+      buildCollateralPsbt({
+        opReturnHex: SAMPLE_OP_RETURN_HEX,
+        xpub: SAMPLE_MAINNET_XPUB,
+        changeAddress: SAMPLE_MAINNET_ADDRESS,
+        syscoinClient: {},
+      })
+    ).rejects.toThrow(/syscoinClient/);
+  });
+
+  test('rejects malformed syscoinClient (missing bitcoinjs/export)', async () => {
+    await expect(
+      buildCollateralPsbt({
+        opReturnHex: SAMPLE_OP_RETURN_HEX,
+        xpub: SAMPLE_MAINNET_XPUB,
+        changeAddress: SAMPLE_MAINNET_ADDRESS,
+        syscoinClient: {
+          createTransaction: async () => ({ psbt: {}, fee: 0 }),
+        },
+      })
+    ).rejects.toThrow(/malformed/);
+  });
+});

--- a/lib/proposalPsbt.test.js
+++ b/lib/proposalPsbt.test.js
@@ -134,17 +134,19 @@ describe('assertXpubMatchesNetwork', () => {
     ).not.toThrow();
   });
 
-  test('rejects cross-network xpub with network_mismatch', () => {
-    expect.assertions(2);
+  test('rejects cross-network xpub with network_mismatch tagged field=xpub', () => {
+    expect.assertions(4);
     try {
       assertXpubMatchesNetwork(SAMPLE_MAINNET_XPUB, 'testnet');
     } catch (err) {
       expect(err.code).toBe('network_mismatch');
+      expect(err.field).toBe('xpub');
     }
     try {
       assertXpubMatchesNetwork(SAMPLE_TESTNET_XPUB, 'mainnet');
     } catch (err) {
       expect(err.code).toBe('network_mismatch');
+      expect(err.field).toBe('xpub');
     }
   });
 
@@ -174,7 +176,7 @@ describe('assertChangeAddress', () => {
     ).not.toThrow();
   });
 
-  test('maps cross-network bitcoinjs error to network_mismatch', () => {
+  test('maps cross-network bitcoinjs error to network_mismatch tagged field=changeAddress', () => {
     try {
       assertChangeAddress(
         makeFakeBitcoinjs('sys1'),
@@ -185,6 +187,7 @@ describe('assertChangeAddress', () => {
       throw new Error('should have thrown');
     } catch (err) {
       expect(err.code).toBe('network_mismatch');
+      expect(err.field).toBe('changeAddress');
     }
   });
 
@@ -275,6 +278,47 @@ describe('translateSyscoinError', () => {
 
   test('unknown error shape -> pali_psbt_build_failed', () => {
     const e = translateSyscoinError({ message: 'weird' });
+    expect(e.code).toBe('pali_psbt_build_failed');
+  });
+
+  // Codex PR10 round 2: undici fetch (Node 18+) throws
+  // TypeError('fetch failed') with the real errno nested under
+  // `.cause.code`. A top-level-only check would misclassify those
+  // as generic build failures and 500 the client instead of
+  // 502-upstream-unreachable-ing them.
+  test('unwraps TypeError(fetch failed) with nested cause.code to blockbook_unreachable', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9130'), {
+      code: 'ECONNREFUSED',
+    });
+    const fetchErr = Object.assign(new TypeError('fetch failed'), { cause });
+    const e = translateSyscoinError(fetchErr);
+    expect(e.code).toBe('blockbook_unreachable');
+    expect(e.detail).toBe('ECONNREFUSED');
+    expect(e.cause).toBe(fetchErr);
+  });
+
+  test('unwraps undici-specific UND_ERR_* errno from deeper cause chain', () => {
+    const deep = Object.assign(new Error('timeout'), {
+      code: 'UND_ERR_CONNECT_TIMEOUT',
+    });
+    const mid = Object.assign(new Error('connect'), { cause: deep });
+    const top = Object.assign(new TypeError('fetch failed'), { cause: mid });
+    const e = translateSyscoinError(top);
+    expect(e.code).toBe('blockbook_unreachable');
+    expect(e.detail).toBe('UND_ERR_CONNECT_TIMEOUT');
+  });
+
+  test('TypeError(fetch failed) with no identifiable errno still maps to blockbook_unreachable', () => {
+    const e = translateSyscoinError(new TypeError('fetch failed'));
+    expect(e.code).toBe('blockbook_unreachable');
+    expect(e.detail).toBe('fetch_failed');
+  });
+
+  test('cause chain cycles do not hang', () => {
+    const a = { message: 'a' };
+    const b = { message: 'b', cause: a };
+    a.cause = b; // cycle
+    const e = translateSyscoinError(a);
     expect(e.code).toBe('pali_psbt_build_failed');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "papaparse": "5.4.1",
         "pm2": "5.3.0",
         "pretty-ms": "6.0.1",
+        "syscoinjs-lib": "^1.0.268",
         "websocket": "1.0.34",
         "zod": "^4.3.6"
       },
@@ -620,6 +621,527 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bitcoinerlab/secp256k1": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.2.0.tgz",
+      "integrity": "sha512-jeujZSzb3JOZfmJYI0ph1PVpCRV5oaexCgy+RvCXV8XlY+XFB/2n3WOcvBsKLsOw78KYgnQrQWb2HrKE4be88Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^1.7.0"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0",
+        "bech32": "1.1.4",
+        "ws": "8.18.0"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.6.1",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1683,11 +2205,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1994,6 +2530,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -2138,6 +2683,24 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
+    "node_modules/@types/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/secp256k1": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.7.tgz",
+      "integrity": "sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -2161,6 +2724,19 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/abstract-leveldown": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2324,6 +2900,21 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axios": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
@@ -2481,6 +3072,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2523,6 +3120,12 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
+    },
     "node_modules/better-sqlite3": {
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
@@ -2557,6 +3160,150 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "node_modules/bip174": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-3.0.0.tgz",
+      "integrity": "sha512-N3vz3rqikLEu0d6yQL8GTrSkpYb35NQKWMR7Hlza0lOj6ZOlvQ3Xr7N9Y+JPebaCVoEUHdBeBSuLxcHr71r+Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.9",
+        "varuint-bitcoin": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bip174/node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bip32": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-5.0.1.tgz",
+      "integrity": "sha512-PWlHIAgYCfVhwqNpZyeakHXuLAGyN6rEQZnhxHxKI3BoFJRVWLl26455fhRlHsmbYcV986HqtPnt33Edu5sTCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "@scure/base": "^1.1.1",
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/bip32/node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
+      "license": "MIT"
+    },
+    "node_modules/bitcoinjs-lib": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-7.0.1.tgz",
+      "integrity": "sha512-vwEmpL5Tpj0I0RBdNkcDMXePoaYSTeKY6mL6/l5esbnTs+jGdPDuLp4NY1hSh6Zk5wSgePygZ4Wx5JJao30Pww==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bech32": "^2.0.0",
+        "bip174": "^3.0.0",
+        "bs58check": "^4.0.0",
+        "uint8array-tools": "^0.0.9",
+        "valibot": "^1.2.0",
+        "varuint-bitcoin": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/bitcoinjs-lib/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/uint8array-tools": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.9.tgz",
+      "integrity": "sha512-9vqDWmoSXOoi+K14zNaf6LBV51Q8MayF0/IiQs3GlygIKUYtog603e6virExkjjFosfJUBI4LhbQK1iq8IG11A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/bitcoinjs-lib/node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -2568,6 +3315,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
     "node_modules/blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
@@ -2578,6 +3331,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
     },
     "node_modules/bodec": {
       "version": "0.1.0",
@@ -2627,6 +3386,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -2659,6 +3438,25 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/bser": {
@@ -2708,6 +3506,12 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "license": "MIT"
+    },
     "node_modules/bufferutil": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
@@ -2726,6 +3530,24 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2868,6 +3690,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -2910,6 +3746,15 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/coinselectsyscoin": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/coinselectsyscoin/-/coinselectsyscoin-1.1.10.tgz",
+      "integrity": "sha512-EwU4GlyOi8lXjtYkaVRz6U7ygVJJ2qiNmZNE3Ct9J/iyGvdqE0PiJjIG0kGJ/zRBagYGP0QysTKOQRlhLxvMdg==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.1.3"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -3051,6 +3896,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -3061,6 +3912,33 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "node_modules/create-jest": {
@@ -3241,6 +4119,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deferred-leveldown": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
+      "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "~5.0.0",
+        "inherits": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/degenerator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -3337,6 +4246,49 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecpair": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ecpair/-/ecpair-3.0.1.tgz",
+      "integrity": "sha512-uz8wMFvtdr58TLrXnAesBsoMEyY8UudLOfApcyg40XfZjP+gt1xO4cuZSIkZ8hTMTQ8+ETgt7xSIV4eM7M6VNw==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.8",
+        "valibot": "^1.2.0",
+        "wif": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/ecpair/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ecpair/node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -3348,6 +4300,27 @@
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
@@ -3385,6 +4358,44 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding-down": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "^5.0.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0",
+        "xtend": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -3403,6 +4414,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
       }
     },
     "node_modules/error-ex": {
@@ -3589,6 +4612,157 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eth-object": {
+      "version": "1.0.3",
+      "resolved": "git+ssh://git@github.com/syscoin/eth-object.git#b5ff300f57c136138b31d6e570c816a147e0f1c9",
+      "license": "ISC",
+      "dependencies": {
+        "eth-util-lite": "^1.0.1"
+      }
+    },
+    "node_modules/eth-proof": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/eth-proof/-/eth-proof-2.1.6.tgz",
+      "integrity": "sha512-9QUFDngx/rFW+uX1npookRdJlp/5bBpkAPrmUf7DM27vQqJp+zW4fJtG/P6A+b8rXlCw9uqczIdtAQZ5V/CI8w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "eth-object": "^1.0.3",
+        "eth-util-lite": "^1.0.1",
+        "isomorphic-rpc": "^1.2.1",
+        "merkle-patricia-tree": "github:zmitton/merkle-patricia-tree#build",
+        "promisfy": "^1.2.0"
+      }
+    },
+    "node_modules/eth-proof/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/eth-util-lite": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eth-util-lite/-/eth-util-lite-1.0.1.tgz",
+      "integrity": "sha512-I9zp4kqxEjYhyvpAlap4uupvlwIgCUMDcZCaPNcny6wYUA2hhBkNlAwsMaqhTa19LpYVWsd9TABdx8M1ZUrJ2A==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.8",
+        "js-sha3": "^0.8.0",
+        "rlp": "^2.2.3",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/eth-util-lite/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/ethereumjs-util": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "^0.1.3",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/ethereumjs-util/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -3602,6 +4776,16 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
       "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg=="
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -3867,15 +5051,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -3883,6 +5068,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -3971,6 +5171,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -4185,6 +5391,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -4210,6 +5428,73 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4228,6 +5513,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/html-escaper": {
@@ -4376,6 +5672,12 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha512-RrGCXRm/fRVqMIhqXrGEX9rRADavPiDFSoMb/k64i9XMk8uH4r/Omi5Ctierj6XzNecwDbO4WuFbDD1zmpl3Tg==",
+      "license": "MIT"
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4469,6 +5771,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -4522,6 +5836,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4543,10 +5867,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4554,6 +5899,25 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-rpc": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-rpc/-/isomorphic-rpc-1.2.2.tgz",
+      "integrity": "sha512-0lhERXlo5ySVfSDRQT9aCt38yMsxTe8nOv9Zqu+ft2Jl3ETyBe09pjVGGe8FZuOGpuuuBLV+Yet6OgxUARDJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic-fetch": "^2.2.1"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6430,6 +7794,12 @@
         "pako": "^0.2.5"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6495,6 +7865,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/keccak": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6511,6 +7896,176 @@
       "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
       "engines": {
         "node": ">=0.2.0"
+      }
+    },
+    "node_modules/level-codec": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "deprecated": "Superseded by level-transcoder (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "errno": "~0.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-iterator-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
+      "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-iterator-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/level-iterator-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/level-iterator-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/level-iterator-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/level-mem": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
+      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
+      "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "level-packager": "~4.0.0",
+        "memdown": "~3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-packager": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
+      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-down": "~5.0.0",
+        "levelup": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-ws": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
+      "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.8",
+        "xtend": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/level-ws/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/level-ws/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/level-ws/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/level-ws/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/levelup": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
+      "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
+      "deprecated": "Superseded by abstract-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "deferred-leveldown": "~4.0.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~3.0.0",
+        "xtend": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/leven": {
@@ -6589,6 +8144,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
+      "license": "MIT"
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -6623,6 +8184,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6630,6 +8202,30 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memdown": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
+      "deprecated": "Superseded by memory-level (https://github.com/Level/community#faq)",
+      "license": "MIT",
+      "dependencies": {
+        "abstract-leveldown": "~5.0.0",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/memdown/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -6642,6 +8238,20 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merkle-patricia-tree": {
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/zmitton/merkle-patricia-tree.git#3e33005b879d839dea2239cae9e65171f2cc17a2",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "async": "^2.6.1",
+        "ethereumjs-util": "^5.2.0",
+        "level-mem": "^3.0.1",
+        "level-ws": "^1.0.0",
+        "readable-stream": "^3.0.6",
+        "rlp": "^2.0.0",
+        "semaphore": ">=1.0.1"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -6716,6 +8326,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -6849,6 +8471,31 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/node-fetch/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -7245,6 +8892,23 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -7517,6 +9181,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -7606,6 +9279,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/promisfy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/promisfy/-/promisfy-1.2.0.tgz",
+      "integrity": "sha512-9S6NY6pVlmrvQX/KIZn4V8EPcKNAC0l5nEKXTa5K1/uzqnMOn4ivWtQY+IbSE/f9uLUa1T/kbDsASSzi05X3dA==",
+      "license": "ISC"
+    },
     "node_modules/promptly": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
@@ -7684,6 +9369,12 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "license": "MIT"
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -7729,6 +9420,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -7919,6 +9619,31 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rlp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
+      }
+    },
     "node_modules/run-series": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
@@ -7966,6 +9691,41 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "license": "MIT"
+    },
+    "node_modules/secp256k1": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
+      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/secp256k1/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "license": "MIT"
+    },
+    "node_modules/semaphore": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
+      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -8020,10 +9780,53 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8397,6 +10200,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-hex-prefixed": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -8528,6 +10344,66 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/syscoinjs-lib": {
+      "version": "1.0.268",
+      "resolved": "https://registry.npmjs.org/syscoinjs-lib/-/syscoinjs-lib-1.0.268.tgz",
+      "integrity": "sha512-CUVbqgo201I12oqXa3hPeFjPa0xHsK7xeCkVyo/GpgzB3Kd2cbnqO3+3yCJXoaZ3uZbNxevXtORCDUDyKqsviw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/secp256k1": "^1.2.0",
+        "@ethersproject/abi": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/providers": "^5.8.0",
+        "axios": "^1.13.2",
+        "bip32": "^5.0.0-rc.0",
+        "bip39": "^3.1.0",
+        "bitcoin-ops": "^1.4.1",
+        "bitcoinjs-lib": "^7.0.0-rc.0",
+        "bn.js": "^5.1.3",
+        "bs58": "^6.0.0",
+        "ecpair": "^3.0.0-rc.0",
+        "eth-object": "git+https://github.com/syscoin/eth-object.git",
+        "eth-proof": "^2.1.6",
+        "syscointx-js": "^1.0.124",
+        "varuint-bitcoin": "^2.0.0"
+      }
+    },
+    "node_modules/syscoinjs-lib/node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/syscoinjs-lib/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/syscointx-js": {
+      "version": "1.0.124",
+      "resolved": "https://registry.npmjs.org/syscointx-js/-/syscointx-js-1.0.124.tgz",
+      "integrity": "sha512-E/WOCrXAETgnSYNrRHxCmb910a7sn6P2wuypbYtTDKGGp4RnnQ+yCSR81gDXkimvR9rrYEwfZsWWlPbApbXh9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@bitcoinerlab/secp256k1": "^1.2.0",
+        "bitcoin-ops": "^1.4.1",
+        "bitcoinjs-lib": "^7.0.0-rc.0",
+        "bn.js": "^5.1.3",
+        "coinselectsyscoin": "^1.1.10",
+        "ecpair": "^3.0.0-rc.0",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "^2.0.0"
+      }
+    },
     "node_modules/systeminformation": {
       "version": "5.25.11",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
@@ -8603,6 +10479,20 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -8706,6 +10596,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -8713,6 +10617,12 @@
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "3.9.10",
@@ -8724,6 +10634,15 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/undefsafe": {
@@ -8821,6 +10740,15 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/varuint-bitcoin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.8"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -8869,6 +10797,12 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8883,6 +10817,36 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "^4.0.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -8940,6 +10904,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "papaparse": "5.4.1",
     "pm2": "5.3.0",
     "pretty-ms": "6.0.1",
+    "syscoinjs-lib": "^1.0.268",
     "websocket": "1.0.34",
     "zod": "^4.3.6"
   },

--- a/routes/govProposals.js
+++ b/routes/govProposals.js
@@ -406,6 +406,20 @@ function createGovProposalsRouter({
   now = () => Date.now(),
   maxDraftsPerUser = DEFAULT_MAX_DRAFTS_PER_USER,
   maxPaymentCount = DEFAULT_MAX_PAYMENT_COUNT,
+  // Optional: info about the chain this backend is pinned to. Used by
+  // GET /network and as the authoritative `networkKey` for PSBT builds.
+  // When null, we treat the chain as unknown and skip network probes.
+  // Shape: { chain: 'main'|'test'|'regtest', slip44: number,
+  //          networkKey: 'mainnet'|'testnet' }.
+  networkInfo = null,
+  // Optional: collateral-PSBT builder. Injected by appFactory when
+  // SYSCOIN_BLOCKBOOK_URL is set. A typed function:
+  //   async ({ opReturnHex, xpub, changeAddress, feeRate }) ->
+  //     { psbt, feeSats }
+  // When null, POST /submissions/:id/collateral/psbt returns 503 and
+  // GET /network reports paliPathEnabled=false so the FE can keep
+  // the "Pay with Pali" button hidden.
+  buildCollateralPsbt = null,
 } = {}) {
   if (!drafts || typeof drafts.create !== 'function') {
     throw new Error('createGovProposalsRouter: drafts repo is required');
@@ -1031,6 +1045,212 @@ function createGovProposalsRouter({
     const row = submissions.getByIdForUser(id, userId);
     if (!row) return res.status(404).json({ error: 'not_found' });
     return res.json({ submission: jsonSubmission(row) });
+  });
+
+  // -----------------------------------------------------------------
+  // GET /gov/proposals/network
+  //
+  // Surfaces the chain this backend is pinned to so the frontend can
+  // gate the "Pay with Pali" button on a chain match (and pick the
+  // right copy — "Switch Pali to Syscoin mainnet", etc.). Purely
+  // informational; never mutates state. Requires auth because it
+  // rides the same router chain as the rest of /gov/proposals, which
+  // is fine — callers that need it are authenticated by construction
+  // (you have to be logged in to be in the proposal wizard).
+  //
+  // Output: 200 {
+  //   chain: 'main' | 'test' | 'regtest' | 'unknown',
+  //   slip44: 57 | 1 | null,
+  //   networkKey: 'mainnet' | 'testnet' | null,
+  //   paliPathEnabled: boolean        // true iff the PSBT builder is
+  //                                     wired (= SYSCOIN_BLOCKBOOK_URL
+  //                                     is set AND networkInfo is
+  //                                     known)
+  // }
+  // -----------------------------------------------------------------
+  router.get('/network', (req, res) => {
+    const info = networkInfo || {};
+    const paliPathEnabled =
+      typeof buildCollateralPsbt === 'function' &&
+      (info.networkKey === 'mainnet' || info.networkKey === 'testnet');
+    return res.json({
+      chain: info.chain || 'unknown',
+      slip44: Number.isInteger(info.slip44) ? info.slip44 : null,
+      networkKey: info.networkKey || null,
+      paliPathEnabled,
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // POST /gov/proposals/submissions/:id/collateral/psbt
+  //
+  // Build an UNSIGNED collateral PSBT for Pali to sign. Only callable
+  // while the submission is still in `prepared` state; once the user
+  // has attached a txid, the dispatcher owns the row and rebuilding
+  // a PSBT would produce a second collateral tx that Core would
+  // reject as a duplicate. Guards here mirror /attach-collateral so
+  // the two paths can't race.
+  //
+  // Input:
+  //   {
+  //     xpub: string,           // Syscoin zpub (mainnet) or vpub (testnet)
+  //     changeAddress: string,  // valid address on the same network
+  //     feeRate?: number        // sat/vByte, default 10, clamped 1..1000
+  //   }
+  //
+  // Output:
+  //   200 { psbt: { psbt: '<base64>', assets: '[]' },
+  //         feeSats: '<integer>',
+  //         opReturnHex,              // echo for FE sanity-check
+  //         collateralFeeSats: '15000000000',
+  //         networkKey: 'mainnet' | 'testnet' }
+  //
+  // Errors:
+  //   401 unauthorized              (sessionMw)
+  //   403 csrf_missing / csrf_invalid
+  //   404 not_found                 (unknown / other user's submission)
+  //   409 conflict: status_not_prepared
+  //   400 validation_failed         (bad_xpub, bad_change_address, bad_fee_rate,
+  //                                  network_mismatch, bad_op_return)
+  //   422 unprocessable             (insufficient_funds)
+  //   503 pali_path_disabled        (no SYSCOIN_BLOCKBOOK_URL configured)
+  //   502 upstream_unreachable      (Blockbook unreachable)
+  //
+  // The `insufficient_funds` -> 422 split (rather than 400) reflects
+  // that the request shape was fine; the user's wallet just didn't
+  // have 150+ SYS. The FE distinguishes on the status code so its
+  // error copy can be specific.
+  // -----------------------------------------------------------------
+  router.post('/submissions/:id/collateral/psbt', async (req, res) => {
+    if (typeof buildCollateralPsbt !== 'function') {
+      return res
+        .status(503)
+        .json({ error: 'pali_path_disabled' });
+    }
+
+    const userId = req.user.id;
+    const id = parseIntId(req.params.id);
+    if (!id) return res.status(404).json({ error: 'not_found' });
+
+    const row = submissions.getByIdForUser(id, userId);
+    if (!row) return res.status(404).json({ error: 'not_found' });
+    if (row.status !== 'prepared') {
+      return res
+        .status(409)
+        .json({ error: 'conflict', reason: 'status_not_prepared' });
+    }
+
+    const body = req.body || {};
+    const xpub = typeof body.xpub === 'string' ? body.xpub.trim() : '';
+    const changeAddress =
+      typeof body.changeAddress === 'string' ? body.changeAddress.trim() : '';
+    const feeRate = body.feeRate;
+
+    if (!xpub) {
+      return res.status(400).json({
+        error: 'validation_failed',
+        issues: [
+          { field: 'xpub', code: 'required', message: 'xpub is required.' },
+        ],
+      });
+    }
+    if (!changeAddress) {
+      return res.status(400).json({
+        error: 'validation_failed',
+        issues: [
+          {
+            field: 'changeAddress',
+            code: 'required',
+            message: 'changeAddress is required.',
+          },
+        ],
+      });
+    }
+
+    // Recompute opReturnHex from the stored row so we're building
+    // against the exact bytes Core will check. Mirrors the idempotent
+    // replay at the top of /prepare (line ~819) rather than trusting
+    // any FE-supplied hash.
+    let opReturnHex;
+    try {
+      opReturnHex = computeProposalHash({
+        parentHash: row.parentHash,
+        revision: row.revision,
+        time: row.timeUnix,
+        dataHex: row.dataHex,
+      }).opReturnBytes.toString('hex');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[POST /gov/proposals/submissions/:id/collateral/psbt] rehash',
+        err
+      );
+      return res.status(500).json({ error: 'internal' });
+    }
+
+    let built;
+    try {
+      built = await buildCollateralPsbt({
+        opReturnHex,
+        xpub,
+        changeAddress,
+        feeRate,
+      });
+    } catch (err) {
+      const code = err && err.code;
+      if (
+        code === 'bad_xpub' ||
+        code === 'bad_change_address' ||
+        code === 'bad_fee_rate' ||
+        code === 'bad_op_return' ||
+        code === 'network_mismatch'
+      ) {
+        return res.status(400).json({
+          error: 'validation_failed',
+          issues: [
+            {
+              field:
+                code === 'bad_xpub'
+                  ? 'xpub'
+                  : code === 'bad_change_address'
+                  ? 'changeAddress'
+                  : code === 'bad_fee_rate'
+                  ? 'feeRate'
+                  : code === 'network_mismatch'
+                  ? 'xpub'
+                  : 'opReturnHex',
+              code,
+              message: (err && err.detail) || err.message || code,
+            },
+          ],
+        });
+      }
+      if (code === 'insufficient_funds') {
+        return res.status(422).json({
+          error: 'insufficient_funds',
+          shortfallSats: err.shortfallSats || null,
+        });
+      }
+      if (code === 'blockbook_unreachable') {
+        return res
+          .status(502)
+          .json({ error: 'upstream_unreachable', detail: err.detail });
+      }
+      // eslint-disable-next-line no-console
+      console.error(
+        '[POST /gov/proposals/submissions/:id/collateral/psbt] build',
+        err
+      );
+      return res.status(500).json({ error: 'internal' });
+    }
+
+    return res.status(200).json({
+      psbt: built.psbt,
+      feeSats: built.feeSats,
+      opReturnHex,
+      collateralFeeSats: COLLATERAL_FEE_SATS.toString(),
+      networkKey: (networkInfo && networkInfo.networkKey) || null,
+    });
   });
 
   // POST /gov/proposals/submissions/:id/attach-collateral

--- a/routes/govProposals.js
+++ b/routes/govProposals.js
@@ -1253,20 +1253,26 @@ function createGovProposalsRouter({
         code === 'bad_op_return' ||
         code === 'network_mismatch'
       ) {
+        // `network_mismatch` can come from either xpub-prefix or
+        // change-address HRP validation — the thrower tags the
+        // failing input via `err.field` so we highlight the right
+        // form control downstream. Other codes have a single
+        // unambiguous origin field.
+        let field;
+        if (code === 'bad_xpub') field = 'xpub';
+        else if (code === 'bad_change_address') field = 'changeAddress';
+        else if (code === 'bad_fee_rate') field = 'feeRate';
+        else if (code === 'bad_op_return') field = 'opReturnHex';
+        else if (code === 'network_mismatch') {
+          field = err && (err.field === 'xpub' || err.field === 'changeAddress')
+            ? err.field
+            : 'xpub';
+        }
         return res.status(400).json({
           error: 'validation_failed',
           issues: [
             {
-              field:
-                code === 'bad_xpub'
-                  ? 'xpub'
-                  : code === 'bad_change_address'
-                  ? 'changeAddress'
-                  : code === 'bad_fee_rate'
-                  ? 'feeRate'
-                  : code === 'network_mismatch'
-                  ? 'xpub'
-                  : 'opReturnHex',
+              field,
               code,
               message: (err && err.detail) || err.message || code,
             },

--- a/routes/govProposals.js
+++ b/routes/govProposals.js
@@ -420,6 +420,23 @@ function createGovProposalsRouter({
   // GET /network reports paliPathEnabled=false so the FE can keep
   // the "Pay with Pali" button hidden.
   buildCollateralPsbt = null,
+  // Optional: chain-verification guard that cross-checks the
+  // operator-declared network (SYSCOIN_NETWORK) against the actual
+  // chain behind the RPC node. Until the guard reports `isReady()`
+  // we refuse the Pali path — otherwise a misconfigured deploy
+  // could let users burn 150 SYS on chain A while the dispatcher
+  // watches chain B. Interface:
+  //   { isReady(): boolean, reason(): string|null }
+  // `reason()` returns one of:
+  //   'pali_not_configured'       — no SYSCOIN_NETWORK declared
+  //   'pali_path_rpc_down'        — RPC unreachable; retrying
+  //   'pali_path_chain_mismatch'  — env vs RPC chain disagree
+  //                                 (terminal; operator must restart)
+  //   null                        — verified (isReady() === true)
+  // When this prop is null, the router falls back to the bare
+  // buildCollateralPsbt truthiness check (used by tests and any
+  // single-network dev boot where the cross-check is overkill).
+  paliChainGuard = null,
 } = {}) {
   if (!drafts || typeof drafts.create !== 'function') {
     throw new Error('createGovProposalsRouter: drafts repo is required');
@@ -1070,14 +1087,30 @@ function createGovProposalsRouter({
   // -----------------------------------------------------------------
   router.get('/network', (req, res) => {
     const info = networkInfo || {};
-    const paliPathEnabled =
+    const builderWired =
       typeof buildCollateralPsbt === 'function' &&
       (info.networkKey === 'mainnet' || info.networkKey === 'testnet');
+    // If a guard is injected, it has the final say. No guard ==
+    // legacy/dev path: trust the builder wiring alone.
+    const guardReady = paliChainGuard
+      ? typeof paliChainGuard.isReady === 'function' &&
+        paliChainGuard.isReady()
+      : true;
+    const paliPathEnabled = builderWired && guardReady;
+    const reason =
+      !paliPathEnabled && paliChainGuard &&
+      typeof paliChainGuard.reason === 'function'
+        ? paliChainGuard.reason()
+        : null;
     return res.json({
       chain: info.chain || 'unknown',
       slip44: Number.isInteger(info.slip44) ? info.slip44 : null,
       networkKey: info.networkKey || null,
       paliPathEnabled,
+      // Surfaced so the FE can pick the right hint ("verifying RPC
+      // chain…" vs "operator misconfigured, contact admin"). Absent
+      // when the path is enabled.
+      ...(reason ? { paliPathReason: reason } : {}),
     });
   });
 
@@ -1126,6 +1159,21 @@ function createGovProposalsRouter({
       return res
         .status(503)
         .json({ error: 'pali_path_disabled' });
+    }
+    // Guard check BEFORE any state reads. When the guard is injected
+    // and not ready, we refuse regardless of builder wiring — the
+    // builder could succeed against the wrong chain and burn funds
+    // that the dispatcher will never find.
+    if (
+      paliChainGuard &&
+      typeof paliChainGuard.isReady === 'function' &&
+      !paliChainGuard.isReady()
+    ) {
+      const reason =
+        typeof paliChainGuard.reason === 'function'
+          ? paliChainGuard.reason() || 'pali_path_disabled'
+          : 'pali_path_disabled';
+      return res.status(503).json({ error: reason });
     }
 
     const userId = req.user.id;

--- a/server.js
+++ b/server.js
@@ -34,6 +34,10 @@ const { createReminderLog } = require('./lib/reminderLog');
 const { createReminderDispatcher } = require('./lib/reminderDispatcher');
 const { createProposalDispatcher } = require('./lib/proposalDispatcher');
 const { createProposalRpc } = require('./lib/proposalRpc');
+const {
+  buildCollateralPsbt,
+  createDefaultSyscoinClient,
+} = require('./lib/proposalPsbt');
 
 // Per-process cache for `gobject_getcurrentvotes`. Concurrent callers
 // hitting GET /gov/receipts for the same proposal share one RPC; a
@@ -157,6 +161,69 @@ app.use(['/auth', '/vault', '/gov'], services.sessionMw.parse);
 // surface in integration.
 const proposalRpc = createProposalRpc(() => rpcServices(client.callRpc));
 
+// "Pay with Pali" wiring.
+//
+// Both `SYSCOIN_NETWORK` and `SYSCOIN_BLOCKBOOK_URL` must be set for
+// the /collateral/psbt route to function. We pre-wire the syscoinjs
+// client at boot so every request reuses one SyscoinJSLib instance
+// (it's stateless across requests — it only holds a Blockbook URL
+// and a bitcoinjs network object). When either env var is missing we
+// leave `paliPsbtBuilder` null; the gov-proposals router then
+// returns 503 from that route and reports `paliPathEnabled: false`
+// from GET /network, so the FE hides the button cleanly.
+const PALI_NETWORK_KEY = (() => {
+  const raw = String(process.env.SYSCOIN_NETWORK || '').trim().toLowerCase();
+  if (raw === 'mainnet') return 'mainnet';
+  if (raw === 'testnet') return 'testnet';
+  return null;
+})();
+const PALI_BLOCKBOOK_URL =
+  typeof process.env.SYSCOIN_BLOCKBOOK_URL === 'string'
+    ? process.env.SYSCOIN_BLOCKBOOK_URL.trim()
+    : '';
+
+let paliSyscoinClient = null;
+let paliPsbtBuilder = null;
+let paliNetworkInfo = null;
+if (PALI_NETWORK_KEY && PALI_BLOCKBOOK_URL) {
+  try {
+    paliSyscoinClient = createDefaultSyscoinClient({
+      blockbookURL: PALI_BLOCKBOOK_URL,
+      networkKey: PALI_NETWORK_KEY,
+    });
+    paliPsbtBuilder = paliSyscoinClient
+      ? (args) =>
+          buildCollateralPsbt({ ...args, syscoinClient: paliSyscoinClient })
+      : null;
+    paliNetworkInfo = {
+      // `chain` mirrors the string Core returns from getblockchaininfo
+      // so /network readers can compare against a value they've seen
+      // elsewhere. slip44 is the BIP-44 coin type (57 for mainnet SYS,
+      // 1 for any testnet per BIP-44), which Pali's chainId response
+      // can be cross-checked against.
+      chain: PALI_NETWORK_KEY === 'mainnet' ? 'main' : 'test',
+      slip44: PALI_NETWORK_KEY === 'mainnet' ? 57 : 1,
+      networkKey: PALI_NETWORK_KEY,
+    };
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      '[pali] failed to wire Pali PSBT builder; path stays disabled',
+      err && err.message
+    );
+    paliSyscoinClient = null;
+    paliPsbtBuilder = null;
+    paliNetworkInfo = null;
+  }
+} else if (PALI_NETWORK_KEY || PALI_BLOCKBOOK_URL) {
+  // Half-configured: loud warning so the operator notices on boot.
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[pali] SYSCOIN_NETWORK and SYSCOIN_BLOCKBOOK_URL must both be set;' +
+      ' Pali collateral path disabled until both are present.'
+  );
+}
+
 mountAuthAndVault(app, {
   services,
   mailer,
@@ -184,6 +251,8 @@ mountAuthAndVault(app, {
   invalidateCurrentVotes: (proposalHash) =>
     currentVotesCache.invalidate(proposalHash),
   proposalRpc,
+  governanceNetworkInfo: paliNetworkInfo,
+  buildCollateralPsbt: paliPsbtBuilder,
 });
 
 // -----------------------------------------------------------------------------

--- a/server.js
+++ b/server.js
@@ -38,6 +38,7 @@ const {
   buildCollateralPsbt,
   createDefaultSyscoinClient,
 } = require('./lib/proposalPsbt');
+const { createPaliChainGuard } = require('./lib/paliChainGuard');
 
 // Per-process cache for `gobject_getcurrentvotes`. Concurrent callers
 // hitting GET /gov/receipts for the same proposal share one RPC; a
@@ -224,6 +225,41 @@ if (PALI_NETWORK_KEY && PALI_BLOCKBOOK_URL) {
   );
 }
 
+// Chain-verification guard (Codex PR10 P1).
+//
+// Even with both env vars set correctly, the RPC node behind them
+// could be on a different chain (common mistake: repointed
+// SYSCOIN_RPC_HOST without flipping SYSCOIN_NETWORK). If we trust
+// the env blindly, the PSBT builder would happily burn 150 SYS on
+// the env-declared chain while the dispatcher watches the RPC
+// chain — funds gone, submission eternally stuck in
+// `awaiting_collateral` until timeout. The guard probes
+// getblockchaininfo.chain once the RPC is reachable and disables
+// the Pali path on mismatch. We still publish /network with
+// paliPathEnabled=false + paliPathReason so the FE can explain why
+// the button is grey.
+const paliChainGuard = paliNetworkInfo
+  ? createPaliChainGuard({
+      declaredChain: paliNetworkInfo.chain,
+      fetchActualChain: async () => {
+        const info = await rpcServices(client.callRpc)
+          .getBlockchainInfo()
+          .call();
+        return info && info.chain;
+      },
+      log: (level, event, meta) => {
+        // eslint-disable-next-line no-console
+        console[level === 'error' ? 'error' : 'log'](
+          `[pali-guard] ${level} ${event}`,
+          meta || ''
+        );
+      },
+    })
+  : null;
+if (paliChainGuard) {
+  paliChainGuard.start();
+}
+
 mountAuthAndVault(app, {
   services,
   mailer,
@@ -253,6 +289,7 @@ mountAuthAndVault(app, {
   proposalRpc,
   governanceNetworkInfo: paliNetworkInfo,
   buildCollateralPsbt: paliPsbtBuilder,
+  paliChainGuard,
 });
 
 // -----------------------------------------------------------------------------

--- a/server.js
+++ b/server.js
@@ -172,6 +172,15 @@ const proposalRpc = createProposalRpc(() => rpcServices(client.callRpc));
 // leave `paliPsbtBuilder` null; the gov-proposals router then
 // returns 503 from that route and reports `paliPathEnabled: false`
 // from GET /network, so the FE hides the button cleanly.
+//
+// NOTE: the chain declared here via SYSCOIN_NETWORK is ONLY trusted
+// after it's been cross-checked against the actual RPC node's
+// `getblockchaininfo.chain`. That cross-check lives in
+// `paliChainGuard` below (constructed right after this block); the
+// router refuses /collateral/psbt until the guard reports ready, so
+// an operator misconfiguration (e.g. SYSCOIN_NETWORK=mainnet but
+// SYSCOIN_RPC_* pointing at a testnet node) cannot cause users to
+// burn 150 SYS on the wrong chain.
 const PALI_NETWORK_KEY = (() => {
   const raw = String(process.env.SYSCOIN_NETWORK || '').trim().toLowerCase();
   if (raw === 'mainnet') return 'mainnet';

--- a/tests/govProposals.routes.test.js
+++ b/tests/govProposals.routes.test.js
@@ -43,6 +43,7 @@ function buildApp({
   nowRef = null,
   networkInfo = null,
   buildCollateralPsbt = null,
+  paliChainGuard = null,
 } = {}) {
   _resetPepperForTests();
   process.env.SYSNODE_AUTH_PEPPER = 'd'.repeat(64);
@@ -113,6 +114,7 @@ function buildApp({
       ...(nowRef ? { now: () => nowRef.value } : {}),
       ...(networkInfo ? { networkInfo } : {}),
       ...(buildCollateralPsbt ? { buildCollateralPsbt } : {}),
+      ...(paliChainGuard ? { paliChainGuard } : {}),
     })
   );
 
@@ -1699,6 +1701,80 @@ describe('GET /gov/proposals/network', () => {
       ctx.db.close();
     }
   });
+
+  // -----------------------------------------------------------------
+  // paliChainGuard: even when builder+networkInfo are wired, an
+  // unready guard must flip paliPathEnabled=false and surface a
+  // reason code so the FE can show the right hint.
+  // -----------------------------------------------------------------
+  test('guard not ready => paliPathEnabled=false with paliPathReason', async () => {
+    const ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt: async () => ({
+        psbt: { psbt: 'AA==', assets: '[]' },
+        feeSats: '1',
+      }),
+      paliChainGuard: {
+        isReady: () => false,
+        reason: () => 'pali_path_rpc_down',
+      },
+    });
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.get('/gov/proposals/network');
+      expect(res.status).toBe(200);
+      expect(res.body.paliPathEnabled).toBe(false);
+      expect(res.body.paliPathReason).toBe('pali_path_rpc_down');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('guard mismatch flips paliPathEnabled=false with explicit reason', async () => {
+    const ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt: async () => ({
+        psbt: { psbt: 'AA==', assets: '[]' },
+        feeSats: '1',
+      }),
+      paliChainGuard: {
+        isReady: () => false,
+        reason: () => 'pali_path_chain_mismatch',
+      },
+    });
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.get('/gov/proposals/network');
+      expect(res.body).toMatchObject({
+        paliPathEnabled: false,
+        paliPathReason: 'pali_path_chain_mismatch',
+      });
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('guard ready => paliPathEnabled=true and no reason surfaced', async () => {
+    const ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt: async () => ({
+        psbt: { psbt: 'AA==', assets: '[]' },
+        feeSats: '1',
+      }),
+      paliChainGuard: {
+        isReady: () => true,
+        reason: () => null,
+      },
+    });
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.get('/gov/proposals/network');
+      expect(res.body.paliPathEnabled).toBe(true);
+      expect(res.body.paliPathReason).toBeUndefined();
+    } finally {
+      ctx.db.close();
+    }
+  });
 });
 
 // -----------------------------------------------------------------------
@@ -1755,6 +1831,74 @@ describe('POST /gov/proposals/submissions/:id/collateral/psbt', () => {
       .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
     expect(res.status).toBe(503);
     expect(res.body.error).toBe('pali_path_disabled');
+  });
+
+  // Codex PR10: even with builder wired, an unready guard must
+  // refuse with its reason code. Prevents burning 150 SYS on the
+  // wrong chain while the dispatcher watches the other.
+  test('503 from guard when builder wired but guard not ready (mismatch)', async () => {
+    const buildCollateralPsbt = jest.fn();
+    ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt,
+      paliChainGuard: {
+        isReady: () => false,
+        reason: () => 'pali_path_chain_mismatch',
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('pali_path_chain_mismatch');
+    // Critically: we must refuse BEFORE even attempting to build
+    // against a potentially-wrong chain.
+    expect(buildCollateralPsbt).not.toHaveBeenCalled();
+  });
+
+  test('503 from guard when rpc still down', async () => {
+    ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt: async () => ({
+        psbt: { psbt: 'AA==', assets: '[]' },
+        feeSats: '1',
+      }),
+      paliChainGuard: {
+        isReady: () => false,
+        reason: () => 'pali_path_rpc_down',
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('pali_path_rpc_down');
+  });
+
+  test('guard.isReady() === true passes through to the builder', async () => {
+    const buildCollateralPsbt = jest.fn().mockResolvedValue({
+      psbt: { psbt: 'BASE64PSBT==', assets: '[]' },
+      feeSats: '2000',
+    });
+    ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt,
+      paliChainGuard: { isReady: () => true, reason: () => null },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(200);
+    expect(buildCollateralPsbt).toHaveBeenCalledTimes(1);
   });
 
   test('401 without session', async () => {

--- a/tests/govProposals.routes.test.js
+++ b/tests/govProposals.routes.test.js
@@ -2043,11 +2043,12 @@ describe('POST /gov/proposals/submissions/:id/collateral/psbt', () => {
     });
   });
 
-  test('400 network_mismatch maps to xpub validation issue', async () => {
+  test('400 network_mismatch from xpub prefix reports field=xpub', async () => {
     ctx = withBuilder({
       impl: async () => {
         const e = new Error('network_mismatch');
         e.code = 'network_mismatch';
+        e.field = 'xpub';
         e.detail = 'expected zpub... for mainnet';
         throw e;
       },
@@ -2064,6 +2065,52 @@ describe('POST /gov/proposals/submissions/:id/collateral/psbt', () => {
       code: 'network_mismatch',
       message: 'expected zpub... for mainnet',
     });
+  });
+
+  // Codex PR10 round 2 P2: disambiguate which input caused
+  // network_mismatch so the FE highlights the correct form control.
+  test('400 network_mismatch from change-address HRP reports field=changeAddress', async () => {
+    ctx = withBuilder({
+      impl: async () => {
+        const e = new Error('network_mismatch');
+        e.code = 'network_mismatch';
+        e.field = 'changeAddress';
+        e.detail = 'change address is not valid on mainnet';
+        throw e;
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(400);
+    expect(res.body.issues[0]).toEqual({
+      field: 'changeAddress',
+      code: 'network_mismatch',
+      message: 'change address is not valid on mainnet',
+    });
+  });
+
+  // Fallback: legacy callers that throw without setting .field
+  // still get a sensible default of 'xpub' (the most common cause).
+  test('400 network_mismatch with no .field falls back to xpub', async () => {
+    ctx = withBuilder({
+      impl: async () => {
+        const e = new Error('network_mismatch');
+        e.code = 'network_mismatch';
+        e.detail = 'ambiguous';
+        throw e;
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.body.issues[0].field).toBe('xpub');
   });
 
   test('502 on blockbook_unreachable', async () => {

--- a/tests/govProposals.routes.test.js
+++ b/tests/govProposals.routes.test.js
@@ -38,7 +38,12 @@ const { _resetPepperForTests } = require('../lib/kdf');
 const SAMPLE_AUTH =
   'a4f8b3c1d9e7f2a5b1c6d8e4f7a9b2c5d1e8f4a7b3c9d5e1f6a2b8c4d7e3f5a9';
 
-function buildApp({ gObjectCheck = null, nowRef = null } = {}) {
+function buildApp({
+  gObjectCheck = null,
+  nowRef = null,
+  networkInfo = null,
+  buildCollateralPsbt = null,
+} = {}) {
   _resetPepperForTests();
   process.env.SYSNODE_AUTH_PEPPER = 'd'.repeat(64);
   process.env.NODE_ENV = 'test';
@@ -106,6 +111,8 @@ function buildApp({ gObjectCheck = null, nowRef = null } = {}) {
       rpc: gObjectCheck ? { gObjectCheck } : {},
       runAtomic,
       ...(nowRef ? { now: () => nowRef.value } : {}),
+      ...(networkInfo ? { networkInfo } : {}),
+      ...(buildCollateralPsbt ? { buildCollateralPsbt } : {}),
     })
   );
 
@@ -1618,6 +1625,321 @@ describe('submissions lifecycle', () => {
       .delete(`/gov/proposals/submissions/${prep.submission.id}`)
       .set('X-CSRF-Token', b.csrf);
     expect(del.status).toBe(404);
+  });
+});
+
+// -----------------------------------------------------------------------
+// GET /gov/proposals/network
+// -----------------------------------------------------------------------
+
+describe('GET /gov/proposals/network', () => {
+  test('reports paliPathEnabled=false when nothing is wired', async () => {
+    const ctx = buildApp();
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.get('/gov/proposals/network');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        chain: 'unknown',
+        slip44: null,
+        networkKey: null,
+        paliPathEnabled: false,
+      });
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('reports the configured network when both wired', async () => {
+    const ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt: async () => ({
+        psbt: { psbt: 'AA==', assets: '[]' },
+        feeSats: '1',
+      }),
+    });
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.get('/gov/proposals/network');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        chain: 'main',
+        slip44: 57,
+        networkKey: 'mainnet',
+        paliPathEnabled: true,
+      });
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('reports paliPathEnabled=false when networkInfo is set but builder is not', async () => {
+    // Defensive branch: a deploy that configures SYSCOIN_NETWORK but
+    // forgets SYSCOIN_BLOCKBOOK_URL. The server still runs; /network
+    // tells the FE the path is disabled so the button stays hidden.
+    const ctx = buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+    });
+    try {
+      const { agent } = await loggedInAgent(ctx);
+      const res = await agent.get('/gov/proposals/network');
+      expect(res.body.paliPathEnabled).toBe(false);
+      expect(res.body.networkKey).toBe('mainnet');
+    } finally {
+      ctx.db.close();
+    }
+  });
+
+  test('401 without session', async () => {
+    const ctx = buildApp();
+    try {
+      const res = await request(ctx.app).get('/gov/proposals/network');
+      expect(res.status).toBe(401);
+    } finally {
+      ctx.db.close();
+    }
+  });
+});
+
+// -----------------------------------------------------------------------
+// POST /gov/proposals/submissions/:id/collateral/psbt
+// -----------------------------------------------------------------------
+
+describe('POST /gov/proposals/submissions/:id/collateral/psbt', () => {
+  let ctx;
+
+  beforeEach(() => {
+    ctx = null;
+  });
+
+  afterEach(() => {
+    if (ctx) ctx.db.close();
+  });
+
+  async function prepareOne(agent, csrf, overrides = {}) {
+    const res = await agent
+      .post('/gov/proposals/prepare')
+      .set('X-CSRF-Token', csrf)
+      .send(validProposalBody(overrides));
+    if (res.status !== 201) {
+      throw new Error(
+        `prepare failed: ${res.status} ${JSON.stringify(res.body)}`
+      );
+    }
+    return res.body;
+  }
+
+  const SAMPLE_XPUB =
+    'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs';
+  const SAMPLE_CHANGE = 'sys1qw508d6qejxtdg4y5r3zarvary0c5xw7kygmkq9';
+
+  function withBuilder({ impl } = {}) {
+    return buildApp({
+      networkInfo: { chain: 'main', slip44: 57, networkKey: 'mainnet' },
+      buildCollateralPsbt:
+        impl ||
+        (async () => ({
+          psbt: { psbt: 'BASE64PSBT==', assets: '[]' },
+          feeSats: '2000',
+        })),
+    });
+  }
+
+  test('503 pali_path_disabled when builder unwired', async () => {
+    ctx = buildApp();
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('pali_path_disabled');
+  });
+
+  test('401 without session', async () => {
+    ctx = withBuilder();
+    const res = await request(ctx.app)
+      .post('/gov/proposals/submissions/1/collateral/psbt')
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(401);
+  });
+
+  test('403 csrf_missing', async () => {
+    ctx = withBuilder();
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('csrf_missing');
+  });
+
+  test('404 for non-existent submission id', async () => {
+    ctx = withBuilder();
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/proposals/submissions/999999/collateral/psbt')
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(404);
+  });
+
+  test('404 when the submission belongs to another user', async () => {
+    ctx = withBuilder();
+    const a = await loggedInAgent(ctx, 'a@example.com');
+    const b = await loggedInAgent(ctx, 'b@example.com');
+    const prep = await prepareOne(a.agent, a.csrf);
+    const res = await b.agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', b.csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(404);
+  });
+
+  test('409 when submission is already awaiting_collateral', async () => {
+    ctx = withBuilder();
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const txid =
+      'a'.repeat(8) + 'b'.repeat(8) + 'c'.repeat(8) + 'd'.repeat(8) + 'e'.repeat(32);
+    // Move the row past `prepared` via the existing manual path.
+    await agent
+      .post(
+        `/gov/proposals/submissions/${prep.submission.id}/attach-collateral`
+      )
+      .set('X-CSRF-Token', csrf)
+      .send({ collateralTxid: txid });
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(409);
+    expect(res.body.reason).toBe('status_not_prepared');
+  });
+
+  test('400 when xpub missing', async () => {
+    ctx = withBuilder();
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('validation_failed');
+    expect(res.body.issues[0].field).toBe('xpub');
+  });
+
+  test('400 when changeAddress missing', async () => {
+    ctx = withBuilder();
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB });
+    expect(res.status).toBe(400);
+    expect(res.body.issues[0].field).toBe('changeAddress');
+  });
+
+  test('happy path returns PSBT envelope + echoed opReturnHex', async () => {
+    let captured;
+    ctx = withBuilder({
+      impl: async (args) => {
+        captured = args;
+        return {
+          psbt: { psbt: 'BASE64PSBT==', assets: '[]' },
+          feeSats: '2000',
+        };
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE, feeRate: 15 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      psbt: { psbt: 'BASE64PSBT==', assets: '[]' },
+      feeSats: '2000',
+      opReturnHex: prep.opReturnHex,
+      collateralFeeSats: COLLATERAL_FEE_SATS.toString(),
+      networkKey: 'mainnet',
+    });
+    // Builder received the exact args we forwarded, plus the server-
+    // recomputed opReturnHex.
+    expect(captured.xpub).toBe(SAMPLE_XPUB);
+    expect(captured.changeAddress).toBe(SAMPLE_CHANGE);
+    expect(captured.feeRate).toBe(15);
+    expect(captured.opReturnHex).toBe(prep.opReturnHex);
+  });
+
+  test('422 insufficient_funds is not a 500', async () => {
+    ctx = withBuilder({
+      impl: async () => {
+        const e = new Error('insufficient_funds');
+        e.code = 'insufficient_funds';
+        e.shortfallSats = '123';
+        throw e;
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({
+      error: 'insufficient_funds',
+      shortfallSats: '123',
+    });
+  });
+
+  test('400 network_mismatch maps to xpub validation issue', async () => {
+    ctx = withBuilder({
+      impl: async () => {
+        const e = new Error('network_mismatch');
+        e.code = 'network_mismatch';
+        e.detail = 'expected zpub... for mainnet';
+        throw e;
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(400);
+    expect(res.body.issues[0]).toEqual({
+      field: 'xpub',
+      code: 'network_mismatch',
+      message: 'expected zpub... for mainnet',
+    });
+  });
+
+  test('502 on blockbook_unreachable', async () => {
+    ctx = withBuilder({
+      impl: async () => {
+        const e = new Error('blockbook_unreachable');
+        e.code = 'blockbook_unreachable';
+        e.detail = 'ENOTFOUND';
+        throw e;
+      },
+    });
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(`/gov/proposals/submissions/${prep.submission.id}/collateral/psbt`)
+      .set('X-CSRF-Token', csrf)
+      .send({ xpub: SAMPLE_XPUB, changeAddress: SAMPLE_CHANGE });
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('upstream_unreachable');
+    expect(res.body.detail).toBe('ENOTFOUND');
   });
 });
 


### PR DESCRIPTION
## Summary

Server side of the "Pay with Pali" lane for governance proposal collateral. Builds an unsigned PSBT that Pali can sign and broadcast, so users don't have to copy/paste a \`gobject prepare\` command into syscoin-cli.

### What changes

- **New dep**: \`syscoinjs-lib@^1.0.268\` (Node-only; server-side PSBT construction).
- **New module** \`lib/proposalPsbt.js\`:
  - \`buildCollateralPsbt({ opReturnHex, xpub, changeAddress, feeRate?, syscoinClient })\` returns \`{ psbt: { psbt, assets }, feeSats }\` — the exact envelope Pali's \`sys_signAndSend\` consumes.
  - Single output: \`{ script: 0x6a 0x20 <32-byte proposal hash>, value: 15000000000n }\` — matches Syscoin Core's \`IsCollateralValid\` (one unspendable output with value ≥ 150 SYS committing to the proposal hash).
  - RBF disabled on the collateral tx so the 6-conf wait stays stable.
  - Error taxonomy: \`bad_xpub\`, \`bad_change_address\`, \`bad_fee_rate\`, \`insufficient_funds\` (mapped from syscoinjs-lib 402), \`blockbook_unreachable\`, \`network_mismatch\`.
  - \`createDefaultSyscoinClient\` factory for prod use.
- **New routes** in \`routes/govProposals.js\`:
  - \`POST /gov/proposals/submissions/:id/collateral/psbt\` — auth + CSRF + ownership + \`prepared\` guard. Maps typed errors to 400 / 409 / 422 / 502 / 503.
  - \`GET /gov/proposals/network\` — returns \`{ chain, slip44, networkKey, paliPathEnabled }\` for FE feature-detection.
- **Config** (\`.env.example\`): \`SYSCOIN_NETWORK\` + \`SYSCOIN_BLOCKBOOK_URL\`. Either unset → Pali path disabled; FE keeps the manual CLI fallback as the only prompt.

### Safety rails

- Operator must set **both** env vars for the route to accept requests — misconfiguration is explicit, not silent.
- xpub prefix is validated against the configured network (\`zpub\` for mainnet, \`vpub\` for testnet).
- Change-address bech32 HRP is validated against the network.
- Fee rate is clamped to 1..1000 sat/vB.

## Test plan

- [x] \`npm test\` (782 passed, 33 suites).
- [x] \`proposalPsbt\` unit tests: OP_RETURN byte layout, xpub/change-address validation, fee-rate clamping, error translation, and \`buildCollateralPsbt\` integration via stubs.
- [x] Route tests: auth guard, ownership guard, status guard, input validation, insufficient_funds → 422, network_mismatch → 400, blockbook_unreachable → 502, happy path returns PSBT envelope + fee.
- [ ] Manual testnet smoke: install dev Pali, point \`SYSCOIN_NETWORK=testnet\` + Blockbook testnet URL, fund testnet xpub, run the full flow end-to-end via sysnode-info PR.


Made with [Cursor](https://cursor.com)