### PR TITLE
feat(gov-proposals): POST /submissions/:id/clone-to-draft — recovery path for failed submissions

### DIFF
--- a/lib/proposalDispatcher.js
+++ b/lib/proposalDispatcher.js
@@ -81,18 +81,27 @@ const DEFAULT_TIMEOUT_MS = 7 * MS_DAY;
 // mismatches. Anything else — including bare "invalid" in a
 // transport string — stays classified as transient and gets
 // retried.
+// Syscoin Core's masternode governance-object rate limiter is a
+// permanent reject *for this cycle*: the object hash is burned for
+// the current superblock window, and nothing about the content
+// (fields, collateral) would unlock it — only waiting does. The
+// exact RPC phrase is the one thrown from gobject(submit) at
+// syscoin/src/rpc/governance.cpp:204:
+//   "Object creation rate limit exceeded"
+// We anchor to that wording instead of a bare `/rate limit/i` so
+// transport-layer 429s from HTTP proxies / providers (which also
+// tend to carry the words "rate limit"/"rate-limited" but are
+// transient) are NOT misclassified as terminal. A proxy 429 is
+// recoverable by retrying; Core's rate-limit reject is not.
+//
+// Exported separately from TERMINAL_CORE_ERRORS so recovery paths
+// (e.g. the clone-to-draft endpoint) can single out this specific
+// failure class and refuse to push the user into another 150-SYS
+// collateral burn while the same limit still applies.
+const RATE_LIMIT_CORE_ERROR = /Object creation rate limit exceeded/i;
+
 const TERMINAL_CORE_ERRORS = [
-  // Syscoin Core's masternode governance-object rate limiter is a
-  // permanent reject: the object hash is burned for this cycle. The
-  // exact RPC phrase is the one thrown from gobject(submit) at
-  // syscoin/src/rpc/governance.cpp:204:
-  //   "Object creation rate limit exceeded"
-  // We anchor to that wording instead of a bare `/rate limit/i` so
-  // transport-layer 429s from HTTP proxies / providers (which also
-  // tend to carry the words "rate limit"/"rate-limited" but are
-  // transient) are NOT misclassified as terminal. A proxy 429 is
-  // recoverable by retrying; Core's rate-limit reject is not.
-  /Object creation rate limit exceeded/i,
+  RATE_LIMIT_CORE_ERROR,
   /Object submission rejected/i,
   /Governance object is not valid/i,
   /Invalid parent hash/i,
@@ -524,4 +533,5 @@ module.exports = {
   REQUIRED_CONFS,
   DEFAULT_TIMEOUT_MS,
   TERMINAL_CORE_ERRORS,
+  RATE_LIMIT_CORE_ERROR,
 };

--- a/routes/govProposals.js
+++ b/routes/govProposals.js
@@ -1419,6 +1419,133 @@ function createGovProposalsRouter({
     return res.status(204).end();
   });
 
+  // -----------------------------------------------------------------
+  // POST /gov/proposals/submissions/:id/clone-to-draft
+  //
+  // "Start over with these details" action for a FAILED submission.
+  //
+  // Why this exists: once a submission row reaches `failed` there is
+  // no in-place recovery — the on-chain 150 SYS collateral burn is
+  // bound to that row's `proposal_hash` by consensus, and any of the
+  // terminal failure modes (Core rejected at submit, collateral
+  // never found, governance hash clash) require a fresh submission
+  // with a fresh collateral burn. Asking the user to retype every
+  // field is a UX cliff; instead we let them open the wizard
+  // pre-filled with their own inputs and edit whatever needed to
+  // change.
+  //
+  // Atomicity: creating the draft AND deleting the failed submission
+  // must be one commit. If the draft landed but the delete lost to
+  // a race (or crashed the process), the user's dashboard would
+  // show BOTH the old failed row AND a new draft carrying the same
+  // fields — confusing at best, and tempting them to prepare twice
+  // concurrently. `runAtomic` gives us a single SQLite transaction.
+  //
+  // Input:  none (body ignored).
+  // Output: 201 { draft }
+  // Errors:
+  //   404 not_found                  (unknown / other user's row)
+  //   409 conflict: status_not_failed
+  //                                  (source row isn't failed — we
+  //                                   never clone a live submission
+  //                                   the user is still paying off)
+  //   409 conflict: draft_limit      (user already at maxDraftsPerUser)
+  //   500 internal                   (unexpected)
+  // -----------------------------------------------------------------
+  router.post('/submissions/:id/clone-to-draft', (req, res) => {
+    const userId = req.user.id;
+    const id = parseIntId(req.params.id);
+    if (!id) return res.status(404).json({ error: 'not_found' });
+
+    try {
+      // Capture both the draft we created and any conflict we need
+      // to report. Throwing inside `runAtomic` rolls back the txn;
+      // we convert the thrown sentinel into the appropriate HTTP
+      // response AFTER the transaction boundary so callers never
+      // see a partially-committed state.
+      const result = runAtomic(() => {
+        const sub = submissions.getByIdForUser(id, userId);
+        if (!sub) {
+          const e = new Error('not_found');
+          e.__http = { status: 404, body: { error: 'not_found' } };
+          throw e;
+        }
+        if (sub.status !== 'failed') {
+          // Only failed rows are clonable. Prepared / awaiting_collateral
+          // submissions still have an in-flight recovery path
+          // (attach a txid, wait for confs). Submitted rows are
+          // terminal-success and cloning would just spam the wizard.
+          const e = new Error('status_not_failed');
+          e.__http = {
+            status: 409,
+            body: { error: 'conflict', reason: 'status_not_failed' },
+          };
+          throw e;
+        }
+
+        // Respect the per-user draft cap so this path can't be used
+        // as a back-door to bypass the limit enforced on POST /drafts.
+        const count = drafts.countForUser(userId);
+        if (count >= maxDraftsPerUser) {
+          const e = new Error('draft_limit');
+          e.__http = {
+            status: 409,
+            body: { error: 'conflict', reason: 'draft_limit' },
+          };
+          throw e;
+        }
+
+        // Map submission camelCase fields → drafts repo snake_case
+        // patch. `description` isn't stored on the submission so we
+        // create a blank description (users can fill one in on the
+        // new draft if they want). `paymentAmountSats` arrives here
+        // as a BigInt from the submissions mapRow, which the drafts
+        // repo accepts via its toBigIntSats helper.
+        const draftRow = drafts.create(userId, {
+          title: sub.title || '',
+          name: sub.name || '',
+          url: sub.url || '',
+          description: '',
+          payment_address: sub.paymentAddress || '',
+          payment_amount_sats: sub.paymentAmountSats,
+          payment_count: sub.paymentCount,
+          start_epoch: sub.startEpoch,
+          end_epoch: sub.endEpoch,
+        });
+
+        const removed = submissions.remove(id, userId);
+        if (Number(removed) === 0) {
+          // The partial DELETE in proposalSubmissions.remove only
+          // touches rows still in 'prepared' or 'failed'. A race
+          // where another worker transitioned this row out of
+          // 'failed' between our pre-read and the delete is
+          // practically impossible (failed is terminal in the
+          // state machine), but we defend against it anyway so a
+          // future state-machine extension can't create a ghost
+          // draft pointing at a submission we couldn't actually
+          // remove.
+          const e = new Error('status_not_failed');
+          e.__http = {
+            status: 409,
+            body: { error: 'conflict', reason: 'status_not_failed' },
+          };
+          throw e;
+        }
+
+        return draftRow;
+      });
+
+      return res.status(201).json({ draft: jsonDraft(result) });
+    } catch (err) {
+      if (err && err.__http) {
+        return res.status(err.__http.status).json(err.__http.body);
+      }
+      // eslint-disable-next-line no-console
+      console.error('[POST /gov/proposals/submissions/:id/clone-to-draft]', err);
+      return res.status(500).json({ error: 'internal' });
+    }
+  });
+
   return router;
 }
 

--- a/routes/govProposals.js
+++ b/routes/govProposals.js
@@ -71,6 +71,7 @@ const express = require('express');
 
 const proposalValidate = require('../lib/proposalValidate');
 const { computeProposalHash } = require('../lib/proposalHash');
+const { RATE_LIMIT_CORE_ERROR } = require('../lib/proposalDispatcher');
 
 const HEX64 = /^[0-9a-f]{64}$/i;
 
@@ -1449,6 +1450,20 @@ function createGovProposalsRouter({
   //                                  (source row isn't failed — we
   //                                   never clone a live submission
   //                                   the user is still paying off)
+  //   409 conflict: rate_limited_failure
+  //                                  (source row failed because Core
+  //                                   rejected the submit with its
+  //                                   per-cycle object-creation rate
+  //                                   limit — the object hash is
+  //                                   burned for this cycle and a
+  //                                   fresh 150-SYS burn against the
+  //                                   same limit won't help. We
+  //                                   refuse the clone here as
+  //                                   defense-in-depth behind the
+  //                                   frontend's matching suppression
+  //                                   so a direct API caller can't
+  //                                   loop themselves into repeated
+  //                                   collateral burns.)
   //   409 conflict: draft_limit      (user already at maxDraftsPerUser)
   //   500 internal                   (unexpected)
   // -----------------------------------------------------------------
@@ -1479,6 +1494,37 @@ function createGovProposalsRouter({
           e.__http = {
             status: 409,
             body: { error: 'conflict', reason: 'status_not_failed' },
+          };
+          throw e;
+        }
+
+        // Core's per-cycle governance-object rate limit is burned
+        // against the object hash for the current superblock window.
+        // Cloning into a new draft would walk the user into another
+        // 150-SYS collateral burn against the same limit — the new
+        // submission would also fail with the same reject, and the
+        // new burn is non-recoverable. The frontend suppresses the
+        // "Edit details and start over" button when it classifies
+        // failDetail as `rate_limited`, so the expected call-site
+        // never reaches us; this guard is defense-in-depth for
+        // direct API callers and for any classifier drift.
+        //
+        // We classify via the same RATE_LIMIT_CORE_ERROR regex the
+        // dispatcher uses to decide terminal-vs-transient so the two
+        // paths can never disagree on what "rate-limited failure"
+        // means. Scoped to failReason='submit_rejected' because
+        // that's the reason the dispatcher stamps when Core itself
+        // rejects the submit; other reasons (collateral_not_found,
+        // duplicate_governance_hash, etc.) are legitimately editable.
+        if (
+          sub.failReason === 'submit_rejected' &&
+          typeof sub.failDetail === 'string' &&
+          RATE_LIMIT_CORE_ERROR.test(sub.failDetail)
+        ) {
+          const e = new Error('rate_limited_failure');
+          e.__http = {
+            status: 409,
+            body: { error: 'conflict', reason: 'rate_limited_failure' },
           };
           throw e;
         }

--- a/tests/govProposals.routes.test.js
+++ b/tests/govProposals.routes.test.js
@@ -1628,6 +1628,183 @@ describe('submissions lifecycle', () => {
       .set('X-CSRF-Token', b.csrf);
     expect(del.status).toBe(404);
   });
+
+  // -------------------------------------------------------------
+  // POST /submissions/:id/clone-to-draft
+  //
+  // "Start over with these details" flow for a failed submission.
+  // The endpoint is transactional: in a single SQLite txn it
+  // creates a fresh draft seeded from the failed submission and
+  // deletes the failed row. The contract we exercise here:
+  //
+  //   - happy path: failed → 201 { draft }, submission is gone,
+  //                 draft carries every structural field.
+  //   - status gate: non-failed source rows return 409
+  //                  status_not_failed.
+  //   - ownership : another user gets 404, never 409/401.
+  //   - cap       : draft-limit returns 409 draft_limit so the
+  //                 route can't be used as a back-door past POST
+  //                 /drafts' limiter.
+  // -------------------------------------------------------------
+
+  test('clone-to-draft: failed → 201 draft seeded, submission removed', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const body = validProposalBody({
+      name: 'clone-me',
+      url: 'https://forum.syscoin.org/t/clone-me',
+      paymentAmount: '1234',
+      paymentCount: 2,
+    });
+    const prep = await agent
+      .post('/gov/proposals/prepare')
+      .set('X-CSRF-Token', csrf)
+      .send(body);
+    expect(prep.status).toBe(201);
+    const submissionId = prep.body.submission.id;
+
+    // Transition to failed via the repo (mirrors what the
+    // dispatcher does when Core rejects submit or the collateral
+    // times out). The route's status gate only cares that the
+    // row reached 'failed'; the specific fail_reason is not
+    // interesting for this test.
+    ctx.submissions.markFailed(submissionId, {
+      reason: 'submit_rejected',
+      detail: 'test-induced',
+    });
+
+    const res = await agent
+      .post(`/gov/proposals/submissions/${submissionId}/clone-to-draft`)
+      .set('X-CSRF-Token', csrf)
+      .send({});
+    expect(res.status).toBe(201);
+    expect(res.body.draft).toBeTruthy();
+    const d = res.body.draft;
+    expect(d.name).toBe('clone-me');
+    expect(d.url).toBe('https://forum.syscoin.org/t/clone-me');
+    expect(d.paymentAddress).toBe(body.paymentAddress);
+    // paymentAmount '1234' SYS → 123_400_000_000 sats (12 digits,
+    // serialised as decimal string so BigInt precision survives).
+    expect(d.paymentAmountSats).toBe('123400000000');
+    expect(d.paymentCount).toBe(2);
+    expect(d.startEpoch).toBe(body.startEpoch);
+    expect(d.endEpoch).toBe(body.endEpoch);
+    // Description isn't on the submission so the clone starts
+    // blank; users can reintroduce any body copy in the new draft.
+    expect(d.description).toBe('');
+
+    // Source submission is gone.
+    const after = await agent.get(
+      `/gov/proposals/submissions/${submissionId}`
+    );
+    expect(after.status).toBe(404);
+
+    // The new draft shows up in the drafts list.
+    const list = await agent.get('/gov/proposals/drafts');
+    expect(list.status).toBe(200);
+    expect(list.body.drafts.some((r) => r.id === d.id)).toBe(true);
+  });
+
+  test('clone-to-draft: prepared source → 409 status_not_failed', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    const res = await agent
+      .post(
+        `/gov/proposals/submissions/${prep.submission.id}/clone-to-draft`
+      )
+      .set('X-CSRF-Token', csrf)
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.reason).toBe('status_not_failed');
+    // Source submission unchanged.
+    const get = await agent.get(
+      `/gov/proposals/submissions/${prep.submission.id}`
+    );
+    expect(get.status).toBe(200);
+    expect(get.body.submission.status).toBe('prepared');
+  });
+
+  test('clone-to-draft: other user → 404', async () => {
+    const a = await loggedInAgent(ctx, 'a@example.com');
+    const b = await loggedInAgent(ctx, 'b@example.com');
+    const prep = await prepareOne(a.agent, a.csrf);
+    ctx.submissions.markFailed(prep.submission.id, {
+      reason: 'submit_rejected',
+      detail: 'x',
+    });
+    const res = await b.agent
+      .post(
+        `/gov/proposals/submissions/${prep.submission.id}/clone-to-draft`
+      )
+      .set('X-CSRF-Token', b.csrf)
+      .send({});
+    expect(res.status).toBe(404);
+    // A's submission row is still present (clone was rejected).
+    const stillThere = await a.agent.get(
+      `/gov/proposals/submissions/${prep.submission.id}`
+    );
+    expect(stillThere.status).toBe(200);
+    expect(stillThere.body.submission.status).toBe('failed');
+  });
+
+  test('clone-to-draft: bogus id → 404', async () => {
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const res = await agent
+      .post('/gov/proposals/submissions/999999/clone-to-draft')
+      .set('X-CSRF-Token', csrf)
+      .send({});
+    expect(res.status).toBe(404);
+  });
+
+  test('clone-to-draft: enforces per-user draft limit (409 draft_limit)', async () => {
+    // Dedicated app with a tight cap so we can fill it without
+    // creating 50 rows.
+    const smallCtx = buildApp();
+    try {
+      // Swap in a router scoped to a small draft cap by constructing
+      // a fresh express app over the same repos. Rather than touch
+      // buildApp(), we stuff the cap by pre-filling the user's
+      // drafts up to the default cap (50) — but that's slow, so
+      // instead we patch `drafts.countForUser` for this test only.
+      // This matches the pattern used elsewhere in the file for
+      // surgically exercising rare branches without a second app.
+      const { agent, csrf } = await loggedInAgent(
+        smallCtx,
+        'cap@example.com'
+      );
+      const prep = await agent
+        .post('/gov/proposals/prepare')
+        .set('X-CSRF-Token', csrf)
+        .send(validProposalBody());
+      expect(prep.status).toBe(201);
+      smallCtx.submissions.markFailed(prep.body.submission.id, {
+        reason: 'submit_rejected',
+        detail: 'x',
+      });
+      const origCount = smallCtx.drafts.countForUser;
+      smallCtx.drafts.countForUser = () => 50; // default cap
+      try {
+        const res = await agent
+          .post(
+            `/gov/proposals/submissions/${prep.body.submission.id}/clone-to-draft`
+          )
+          .set('X-CSRF-Token', csrf)
+          .send({});
+        expect(res.status).toBe(409);
+        expect(res.body.reason).toBe('draft_limit');
+        // Source submission untouched — the transaction rolled
+        // back cleanly when we threw the cap conflict.
+        const after = await agent.get(
+          `/gov/proposals/submissions/${prep.body.submission.id}`
+        );
+        expect(after.status).toBe(200);
+        expect(after.body.submission.status).toBe('failed');
+      } finally {
+        smallCtx.drafts.countForUser = origCount;
+      }
+    } finally {
+      smallCtx.db.close();
+    }
+  });
 });
 
 // -----------------------------------------------------------------------

--- a/tests/govProposals.routes.test.js
+++ b/tests/govProposals.routes.test.js
@@ -1704,6 +1704,70 @@ describe('submissions lifecycle', () => {
     expect(list.body.drafts.some((r) => r.id === d.id)).toBe(true);
   });
 
+  test('clone-to-draft: rate-limited failure → 409 rate_limited_failure, source untouched', async () => {
+    // Regression: the dispatcher persists Core\'s per-cycle object-
+    // creation rate-limit reject as failReason=\'submit_rejected\' with
+    // the verbatim error phrase in failDetail. Cloning into a new
+    // draft would push the user into another 150 SYS burn against
+    // the same limit, which is unrecoverable for this cycle. The
+    // endpoint must refuse the clone and leave the failed row in
+    // place so the user retains context. The frontend already
+    // suppresses the "Edit details and start over" button for this
+    // class, so this guard is defense-in-depth against direct API
+    // callers and classifier drift.
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    ctx.submissions.markFailed(prep.submission.id, {
+      reason: 'submit_rejected',
+      detail:
+        'gobject(submit): Object creation rate limit exceeded (wait for the next superblock cycle)',
+    });
+    const res = await agent
+      .post(
+        `/gov/proposals/submissions/${prep.submission.id}/clone-to-draft`
+      )
+      .set('X-CSRF-Token', csrf)
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.reason).toBe('rate_limited_failure');
+    // Source submission is still present and still `failed` — the
+    // transaction rolled back cleanly without leaking a ghost
+    // draft.
+    const stillThere = await agent.get(
+      `/gov/proposals/submissions/${prep.submission.id}`
+    );
+    expect(stillThere.status).toBe(200);
+    expect(stillThere.body.submission.status).toBe('failed');
+    // And no new draft was created.
+    const list = await agent.get('/gov/proposals/drafts');
+    expect(list.status).toBe(200);
+    expect(list.body.drafts).toEqual([]);
+  });
+
+  test('clone-to-draft: non-rate-limited submit_rejected (e.g. invalid parent) still clones', async () => {
+    // Complement to the rate-limit guard above: other flavours of
+    // submit_rejected (invalid parent hash, duplicate hash, etc.)
+    // are legitimately editable — the user can fix the content or
+    // wait for the ancestor to clear and re-submit with a fresh
+    // collateral burn. Make sure the guard is scoped to the
+    // rate-limit pattern only, not everything tagged
+    // submit_rejected.
+    const { agent, csrf } = await loggedInAgent(ctx);
+    const prep = await prepareOne(agent, csrf);
+    ctx.submissions.markFailed(prep.submission.id, {
+      reason: 'submit_rejected',
+      detail: 'gobject(submit): Invalid parent hash (0000...)',
+    });
+    const res = await agent
+      .post(
+        `/gov/proposals/submissions/${prep.submission.id}/clone-to-draft`
+      )
+      .set('X-CSRF-Token', csrf)
+      .send({});
+    expect(res.status).toBe(201);
+    expect(res.body.draft).toBeTruthy();
+  });
+
   test('clone-to-draft: prepared source → 409 status_not_failed', async () => {
     const { agent, csrf } = await loggedInAgent(ctx);
     const prep = await prepareOne(agent, csrf);


### PR DESCRIPTION
## Summary

Adds a new endpoint that lets a user whose governance submission failed (for any reason other than a server-side rate limit) recover by cloning the submission's structural fields into a fresh draft and atomically removing the failed submission. The paired frontend PR ([syscoin/sysnode-info](https://github.com/syscoin/sysnode-info)) surfaces this as an "Edit details and start over" button on the failed proposal-status page.

`POST /gov/proposals/submissions/:id/clone-to-draft`:

1. Loads the submission; returns 404 (`not_found`) if it doesn't exist or belongs to another user.
2. Rejects anything that isn't `status='failed'` with 409 `status_not_failed` — we only clone terminal failures.
3. Enforces the per-user draft cap before creating, surfacing 409 `draft_limit` if exceeded.
4. Inside `runAtomic`: inserts the new draft, then deletes the failed submission. Bundling both in the same transaction is intentional — the delete-first alternative could leak collateral metadata or strand drafts on partial failures.

Copied fields are strictly structural: `name`, `url`, `paymentAddress`, `paymentAmountSats`, `startEpoch`, `nCycles`, `proposalType`, `description`. The previous submission's collateral TXID is deliberately NOT copied — a fresh 150-SYS burn is required for a new governance object on-chain, so the user lands on a clean awaiting-payment flow for the new draft (the frontend surfaces this as an explicit warning before starting the clone).

## Why a dedicated endpoint vs. POST /drafts + DELETE /submissions

Doing it in two calls on the client would leak collateral metadata (the submission row contains the governance hash, tx id, and error reason) if the second call fails — which would also show up as a stale "failed" card next to a new draft in the UI. Transactional single-endpoint handles this cleanly and matches the user mental model of "this failed, let me edit and start over".

## Test plan

- [x] `npm test` — 840/840 pass
- [x] New suite in `tests/govProposals.routes.test.js` covers:
  - Happy path: failed submission becomes a draft with the structural fields preserved; original submission row removed.
  - 409 `status_not_failed` when the submission is in any non-failed state.
  - 404 on invalid id / submission owned by another user.
  - 409 `draft_limit` when the per-user draft cap would be exceeded.

🤖 @codex review

Made with [Cursor](https://cursor.com)