### PR TITLE
feat(mnStats): expose superblock_next_epoch_sec

### DIFF
--- a/data/dataStore.js
+++ b/data/dataStore.js
@@ -27,6 +27,7 @@ module.exports = {
     proposalFee: 0,
     budget: 0,
     superBlockNextDate: 0,
+    superBlockNextEpochSec: 0,
     votingDeadlineDate: 0,
     sb1: 0,
     sb2: 0,

--- a/services/calculations.js
+++ b/services/calculations.js
@@ -95,6 +95,11 @@ function calculations() {
       proposal_fee: data.proposalFee,
       budget: data.budget,
       superblock_date: data.superBlockNextDate,
+      // Numeric next-superblock epoch (UNIX seconds). Callers that
+      // need a machine-readable anchor (governance wizard window
+      // derivation, etc.) should use this instead of parsing the
+      // human-formatted `superblock_date` string.
+      superblock_next_epoch_sec: data.superBlockNextEpochSec || 0,
       voting_deadline: data.votingDeadlineDate,
       sb1: "SB" + data.sb1 / sbTotal + " - " + data.sb1,
       sb2: "SB" + data.sb2 / sbTotal + " - " + data.sb2,

--- a/services/sysMain.js
+++ b/services/sysMain.js
@@ -70,6 +70,12 @@ setInterval(async function sysMain() {
     const diffBlock = data.nextSuperBlock - data.currentBlock;
     const sbDate = Date.now() + diffBlock * data.avgBlockTime;
     data.superBlockNextDate = moment(sbDate).format("MMMM Do YYYY, h:mm:ss a");
+    // Raw next-superblock epoch (UNIX seconds) for API consumers that
+    // need a numeric anchor instead of the human-formatted string
+    // (e.g. the /governance/new wizard's computeProposalWindow).
+    // Kept alongside the formatted date so the two stay in sync
+    // whenever sbDate is recomputed.
+    data.superBlockNextEpochSec = Math.floor(sbDate / 1000);
 
     const voteDeadlineBlock = data.nextSuperBlock - 1728;
     const voteDeadlineDate = Date.now() + (voteDeadlineBlock - data.currentBlock) * data.avgBlockTime;


### PR DESCRIPTION
## Summary

The governance proposal wizard (sysnode-info) needs a numeric next-superblock anchor to derive the on-chain voting window from a user-facing duration input. Today `/mnStats` only surfaces the next-superblock time as a human-formatted string (`superblock_date`), which is for display only and not safe to parse.

- Add `superblock_next_epoch_sec` (UNIX seconds) to `superblock_stats` on the /mnStats response.
- Compute it from the same `sbDate` value that produces `superblock_date` in `services/sysMain.js`, so the two stay in sync.
- Persist it on the in-memory `dataStore` alongside the existing formatted string.

Non-breaking additive change — no existing field removed or reshaped.

## Pairing PR

Consumed by the frontend PR on sysnode-info that replaces the wizard's raw start/end epoch inputs with a single "Duration (months)" field. Merge + deploy this one first; without it the frontend wizard detects the missing field and disables "Prepare proposal" rather than submitting an unanchored window.

## Test plan

- [ ] Manual: `curl /mnStats` and confirm `stats.superblock_stats.superblock_next_epoch_sec` is a positive integer within a few seconds of `Math.floor(new Date(superblock_date).getTime() / 1000)`.
- [ ] Manual: restart the service, observe the value stabilises once the background sysMain poll completes.

Made with [Cursor](https://cursor.com)